### PR TITLE
Using fluent interface for Arg and Program

### DIFF
--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -12,18 +12,18 @@ int main(int argc, char const *argv[]) {
   fmt::print("argv: {}\n", fmt::join(std::vector(argv, argv + argc), ", "));
 
   opzioni::Program program;
-  program.pos({.name = "name", .help = "Your name"});
-  program.opt({.name = "last-name", .help = "Your last name"});
-  program.opt({.name = "v", .help = "Level of verbosity"});
-  program.opt({.name = "d", .help = "A double"});
-  program.flag({.name = "flag", .help = "Long flag"});
-  program.flag({.name = "a", .help = "Short flag a"});
-  program.flag({.name = "b", .help = "Short flag b"});
-  program.opt({.name = "numbers", .help = "A list of numbers"});
+  program.pos("name").help("Your name");
+  program.opt("last-name").help("Your last name");
+  program.opt("v").help("Level of verbosity");
+  program.opt("d").help("A double");
+  program.flag("flag").help("Long flag");
+  program.flag("a").help("Short flag a");
+  program.flag("b").help("Short flag b");
+  program.opt("numbers").help("A list of numbers");
 
-  auto subcmd = program.cmd({.name = "subcmd"});
-  subcmd->pos({.name = "subname", .help = "Your name again, please"});
-  subcmd->flag({.name = "x", .help = "A nested flag"});
+  auto subcmd = program.cmd("subcmd").help("Just showing how subcommands work");
+  subcmd.pos("subname").help("Your name again, please");
+  subcmd.flag("x").help("A nested flag");
 
   auto const args = program(argc, argv);
   fmt::print("\nCommand name: {}\n", args.cmd_name);

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -15,16 +15,13 @@
 
 namespace opzioni {
 
-struct Command {
-  std::string name;
-  std::string epilog;
-  std::string description;
-};
-
 struct Arg {
   std::string name{};
-  std::string help{};
-  bool required = false;
+  std::string description{};
+  bool is_required = false;
+
+  Arg &help(std::string) noexcept;
+  Arg &required() noexcept;
 };
 
 struct ArgValue {
@@ -95,18 +92,22 @@ private:
   void assign_options(ArgMap &, std::map<std::string, std::string> const &) const;
 
 public:
-  std::string name;
-  std::string epilog;
-  std::string description;
+  std::string name{};
+  std::string description{};
+  std::string epilog{};
 
   Program() = default;
-  Program(std::string name, std::string epilog, std::string description)
-      : name(name), epilog(epilog), description(description) {}
+  Program(std::string name) : name(name) {}
+  Program(std::string name, std::string description, std::string epilog)
+      : name(name), description(description), epilog(epilog) {}
 
-  void pos(Arg &&);
-  void opt(Arg &&);
-  void flag(Arg &&);
-  [[no_discard]] Program *cmd(Command const &);
+  Program &help(std::string) noexcept;
+  Program &with_epilog(std::string) noexcept;
+
+  Arg &pos(std::string);
+  Arg &opt(std::string);
+  Arg &flag(std::string);
+  [[no_discard]] Program &cmd(std::string);
   [[no_discard]] ArgMap operator()(int, char const *[]) const;
 
   bool is_flag(std::string const &) const noexcept;

--- a/src/parsing.test.cpp
+++ b/src/parsing.test.cpp
@@ -10,7 +10,7 @@ SCENARIO("positional arguments") {
   opzioni::Program program;
 
   GIVEN("only 1 positional argument") {
-    program.pos({.name = "name"});
+    program.pos("name");
 
     WHEN("the expected argument is not given in CLI") {
       std::array argv{"./test"};
@@ -65,8 +65,8 @@ SCENARIO("positional arguments") {
   }
 
   GIVEN("1 positional argument and 1 subcommand") {
-    program.pos({.name = "name"});
-    program.cmd({.name = "cmd"});
+    program.pos("name");
+    program.cmd("cmd");
 
     WHEN("only the positional is in CLI") {
       std::array argv{"./test", "someone"};


### PR DESCRIPTION
- removed `Command`
- fluent interface in `Arg` via `.help()` and `.required()`
- fluent interface in `Program` via `.help()` and `.with_epilog()`
- `epilog` now comes after `description` in `Program`