### PR TITLE
Create build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: conanio/gcc10:latest
-      options: -u conan -w /home/conan/
+      options: -u root
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2


### PR DESCRIPTION
This PR adds a build and test workflow based on `conanio/gcc10` and [this Meson doc](https://mesonbuild.com/Continuous-Integration.html#github-actions).

Had to use the root user option because we were getting a permission denied error. Raw logs snippet:

```
2020-08-16T20:47:30.5933956Z Syncing repository: ggabriel96/opzioni
2020-08-16T20:47:30.5934349Z ##[group]Getting Git version info
2020-08-16T20:47:30.5934902Z Working directory is '/__w/opzioni/opzioni'
2020-08-16T20:47:30.6012100Z [command]/usr/bin/git version
2020-08-16T20:47:30.6068264Z git version 2.25.1
2020-08-16T20:47:30.6098658Z ##[endgroup]
2020-08-16T20:47:30.6109524Z Deleting the contents of '/__w/opzioni/opzioni'
2020-08-16T20:47:30.6115050Z ##[group]Initializing the repository
2020-08-16T20:47:30.6119052Z [command]/usr/bin/git init /__w/opzioni/opzioni
2020-08-16T20:47:30.6175162Z /__w/opzioni/opzioni/.git: Permission denied
2020-08-16T20:47:30.6179152Z ##[error]The process '/usr/bin/git' failed with exit code 1
```