### PR TITLE
Constexpr program

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ The goals of this library, in order of importance, are:
 
 1. **Be bleeding-edge.**
 
-    This library requires C++20. That limits a lot its potential users, but also allows for the use of the new and powerful features of C++. It also helps to accomplish the previous goals.
+    This library requires C++20.
+    That limits a lot its potential users, but also allows for the use of the new and powerful features of C++.
+    It also helps to accomplish the previous goals.
 
 # Disclaimer
 
@@ -86,13 +88,11 @@ Feel free to take a look at the other, more complex, examples in the same direct
 int main(int argc, char const *argv[]) {
   using namespace opzioni;
 
-  auto const hello =
-      Program("hello")
-          .version("0.1")
-          .intro("Greeting people since the dawn of computing") +
-      Help() *
-      Version() *
-      Pos("name").help("Your name please, so I can greet you");
+  constexpr auto hello =
+      Program("hello").version("0.1").intro(
+          "Greeting people since the dawn of computing") +
+      Help() * Version() *
+          Pos("name").help("Your name please, so I can greet you");
 
   auto const args = hello(argc, argv);
   std::string_view const name = args["name"];
@@ -131,11 +131,11 @@ int main(int argc, char const *argv[]) {
 1. Automatic error handling
 
     ```
-    $ ./build/examples/hello 
-    Missing required arguments: `name`
-
     $ ./build/examples/hello Gabriel Galli
     Unexpected positional argument `Galli`. This program expects 1 positional arguments
+
+    Usage:
+        hello <name> [--help] [--version]
     ```
 
 1. And finally:
@@ -164,7 +164,8 @@ int main(int argc, char const *argv[]) {
 1. Arguments are added to `Program`.
 
     The built-in help and version and a positional called `name`.
-    Note that there is an `operator*` between each argument and an `operator+` between the program and its arguments. This is better explained later.
+    Note that there is an `operator*` between each argument and an `operator+` between the program and its arguments.
+    This is better explained later.
 
 1. The command line arguments are parsed.
 
@@ -177,17 +178,6 @@ int main(int argc, char const *argv[]) {
     std::cout << args.as<std::string_view>("name") << '\n'; // 1
     std::cout << args["name"].as<std::string_view>() << '\n'; // 2
     ```
-
-### `Program` is not `constexpr`! Where is the compile-time stuff?
-
-Actually, everything related to the construction of arguments is marked `consteval`.
-Hence, it is mandatory for every argument to be built at compile-time.
-There is also a `consteval` construction of an array of arguments, allowing for more checks than would
-be possible if only looking at each argument individually, e.g. finding duplicate names.
-
-Unfortunately, `Program` itself is not `constexpr`-enabled.
-The TLDR reason is that it is too hard to make it work and clumsy to use.
-More details in the [Constexpr Arg](https://github.com/ggabriel96/opzioni/pull/43) PR.
 
 # Getting started
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ int main(int argc, char const *argv[]) {
 
   auto const hello =
       Program("hello")
-          .v("0.1")
+          .version("0.1")
           .intro("Greeting people since the dawn of computing") +
       Help() *
       Version() *

--- a/examples/docker.cpp
+++ b/examples/docker.cpp
@@ -15,10 +15,6 @@ using vec = std::vector<T>;
  * It has no affiliation with the Docker project. I just ran `docker --help` and copied the arguments.
  * Hence, none of the docker CLI is my work, I just copied the help text.
  * Also, note that it is not *identical* to the real CLI.
- * ---
- * Almost all arguments are sorted because the actual CLI has them ordered and I copied them in that order.
- * But help and version are added first and opzioni re-arranges the arguments (don't worry about positionals,
- * their relative order is preserved). By the way, in the actual CLI, the `version` flag uses lowercase `-v`.
  */
 int main(int argc, char const *argv[]) {
   using namespace opzioni;
@@ -45,7 +41,7 @@ int main(int argc, char const *argv[]) {
 
   constexpr auto docker =
       Program("docker")
-          .version("version 20.10.1, build 831ebea")
+          .version("20.10.1, build 831ebea")
           .intro("A self-sufficient runtime for containers")
           .details("Run 'docker COMMAND --help' for more information on a command.") +
       Help() * Version() *

--- a/examples/docker.cpp
+++ b/examples/docker.cpp
@@ -67,7 +67,7 @@ int main(int argc, char const *argv[]) {
               .otherwise("~/.docker/cert.pem") *
           Opt("tlskey").help("Path to TLS key file (default {default_value})").otherwise("~/.docker/key.pem") *
           Flg("tlsverify").help("Use TLS and verify the remote") +
-      Cmd(exec) + Cmd(pull);
+      exec + pull;
 
   auto const args = docker(argc, argv);
 

--- a/examples/docker.cpp
+++ b/examples/docker.cpp
@@ -23,85 +23,86 @@ using vec = std::vector<T>;
 int main(int argc, char const *argv[]) {
   using namespace opzioni;
 
-  auto const exec = Program("exec").intro("Run a command in a running container") +
-                    Help() * Flg("detach", "d").help("Detached mode: run command in the background") *
-                        Opt("detach-keys").help("Override the key sequence for detaching a container") *
-                        Opt("env", "e").help("Set environment variables").append() *
-                        Opt("env-file").help("Read in a file of environment variables").append() *
-                        Flg("interactive", "i").help("Keep STDIN open even if not attached") *
-                        Flg("privileged").help("Give extended privileges to the command") *
-                        Flg("tty", "t").help("Allocate a pseudo-TTY") *
-                        Opt("user", "u").help("Username or UID (format: <name|uid>[:<group|gid>])") *
-                        Opt("workdir", "w").help("Working directory inside the container") *
-                        Pos("container").help("Name of the target container") *
-                        Pos("command").help("The command to run in the container").gather();
+  constexpr auto exec = Program("exec").intro("Run a command in a running container") +
+                        Help() * Flg("detach", "d").help("Detached mode: run command in the background") *
+                            Opt("detach-keys").help("Override the key sequence for detaching a container") *
+                            Opt("env", "e").help("Set environment variables").append() *
+                            Opt("env-file").help("Read in a file of environment variables").append() *
+                            Flg("interactive", "i").help("Keep STDIN open even if not attached") *
+                            Flg("privileged").help("Give extended privileges to the command") *
+                            Flg("tty", "t").help("Allocate a pseudo-TTY") *
+                            Opt("user", "u").help("Username or UID (format: <name|uid>[:<group|gid>])") *
+                            Opt("workdir", "w").help("Working directory inside the container") *
+                            Pos("container").help("Name of the target container") *
+                            Pos("command").help("The command to run in the container").gather();
 
-  auto const pull = Program("pull").intro("Pull an image or a repository from a registry") +
-                    Help() * Pos("name").help("The name of the image or repository to pull") *
-                        Flg("all-tags", "a").help("Download all tagged images in the repository") *
-                        Flg("disable-content-trust").help("Skip image verification") *
-                        Opt("platform").help("Set platform if server is multi-platform capable") *
-                        Flg("quiet", "q").help("Supress verbose output");
+  constexpr auto pull = Program("pull").intro("Pull an image or a repository from a registry") +
+                        Help() * Pos("name").help("The name of the image or repository to pull") *
+                            Flg("all-tags", "a").help("Download all tagged images in the repository") *
+                            Flg("disable-content-trust").help("Skip image verification") *
+                            Opt("platform").help("Set platform if server is multi-platform capable") *
+                            Flg("quiet", "q").help("Supress verbose output");
 
-  auto const docker =
-      Program("docker")
-          .version("version 20.10.1, build 831ebea")
-          .intro("A self-sufficient runtime for containers")
-          .details("Run 'docker COMMAND --help' for more information on a command.") +
-      Help() * Version() *
-          Opt("config").help("Location of client config files (default {default_value})").otherwise("~/.docker") *
-          Opt("context", "c")
-              .help("Name of the context to use to connect to the daemon (overrides DOCKER_HOST env var and default "
-                    "context set with \"docker context use\")") *
-          Flg("debug", "D").help("Enable debug mode") *
-          Opt("host", "H").help("Daemon socket(s) to connect to").append() *
-          Opt("log-level", "l")
-              .help("Set the logging level (\"debug\"|\"info\"|\"warn\"|\"error\"|\"fatal\") (default {default_value})")
-              .otherwise("info") *
-          Flg("tls").help("Use TLS; implied by --tlsverify") *
-          Opt("tlscacert")
-              .help("Trust certs signed only by this CA (default {default_value})")
-              .otherwise("~/.docker/ca.pem") *
-          Opt("tlscert")
-              .help("Path to TLS certificate file (default {default_value})")
-              .otherwise("~/.docker/cert.pem") *
-          Opt("tlskey").help("Path to TLS key file (default {default_value})").otherwise("~/.docker/key.pem") *
-          Flg("tlsverify").help("Use TLS and verify the remote") +
-      exec + pull;
+  constexpr auto commands = exec * pull;
+  // constexpr auto docker =
+  //     Program("docker")
+  //         .version("version 20.10.1, build 831ebea")
+  //         .intro("A self-sufficient runtime for containers")
+  //         .details("Run 'docker COMMAND --help' for more information on a command.") +
+  //     exec * pull * pull +
+  //     Help() * Version() *
+  //         Opt("config").help("Location of client config files (default {default_value})").otherwise("~/.docker") *
+  //         Opt("context", "c")
+  //             .help("Name of the context to use to connect to the daemon (overrides DOCKER_HOST env var and default "
+  //                   "context set with \"docker context use\")") *
+  //         Flg("debug", "D").help("Enable debug mode") *
+  //         Opt("host", "H").help("Daemon socket(s) to connect to").append() *
+  //         Opt("log-level", "l")
+  //             .help("Set the logging level (\"debug\"|\"info\"|\"warn\"|\"error\"|\"fatal\") (default {default_value})")
+  //             .otherwise("info") *
+  //         Flg("tls").help("Use TLS; implied by --tlsverify") *
+  //         Opt("tlscacert")
+  //             .help("Trust certs signed only by this CA (default {default_value})")
+  //             .otherwise("~/.docker/ca.pem") *
+  //         Opt("tlscert")
+  //             .help("Path to TLS certificate file (default {default_value})")
+  //             .otherwise("~/.docker/cert.pem") *
+  //         Opt("tlskey").help("Path to TLS key file (default {default_value})").otherwise("~/.docker/key.pem") *
+  //         Flg("tlsverify").help("Use TLS and verify the remote");
 
-  auto const args = docker(argc, argv);
+  // auto const args = docker(argc, argv);
 
-  fmt::print("docker args:\n");
-  fmt::print("- config: {}\n", args.as<strv>("config"));
-  fmt::print("- context: {}\n", args.as<strv>("context"));
-  fmt::print("- debug: {}\n", args.as<bool>("debug"));
-  fmt::print("- host: {}\n", args.as<vec<strv>>("host"));
-  fmt::print("- log-level: {}\n", args.as<strv>("log-level"));
-  fmt::print("- tls: {}\n", args.as<bool>("tls"));
-  fmt::print("- tlscacert: {}\n", args.as<strv>("tlscacert"));
-  fmt::print("- tlscert: {}\n", args.as<strv>("tlscert"));
-  fmt::print("- tlskey: {}\n", args.as<strv>("tlskey"));
-  fmt::print("- tlsverify: {}\n", args.as<bool>("tlsverify"));
+  // fmt::print("docker args:\n");
+  // fmt::print("- config: {}\n", args.as<strv>("config"));
+  // fmt::print("- context: {}\n", args.as<strv>("context"));
+  // fmt::print("- debug: {}\n", args.as<bool>("debug"));
+  // fmt::print("- host: {}\n", args.as<vec<strv>>("host"));
+  // fmt::print("- log-level: {}\n", args.as<strv>("log-level"));
+  // fmt::print("- tls: {}\n", args.as<bool>("tls"));
+  // fmt::print("- tlscacert: {}\n", args.as<strv>("tlscacert"));
+  // fmt::print("- tlscert: {}\n", args.as<strv>("tlscert"));
+  // fmt::print("- tlskey: {}\n", args.as<strv>("tlskey"));
+  // fmt::print("- tlsverify: {}\n", args.as<bool>("tlsverify"));
 
-  if (auto const exec_args = args.cmd("exec")) {
-    fmt::print("\nexec args:\n");
-    fmt::print("- container: {}\n", exec_args->as<strv>("container"));
-    fmt::print("- command: {}\n", exec_args->as<vec<strv>>("command"));
-    fmt::print("- detach: {}\n", exec_args->as<bool>("detach"));
-    fmt::print("- detach-keys: {}\n", exec_args->as<strv>("detach-keys"));
-    fmt::print("- env: {}\n", exec_args->as<vec<strv>>("env"));
-    fmt::print("- env-file: {}\n", exec_args->as<vec<strv>>("env-file"));
-    fmt::print("- interactive: {}\n", exec_args->as<bool>("interactive"));
-    fmt::print("- privileged: {}\n", exec_args->as<bool>("privileged"));
-    fmt::print("- tty: {}\n", exec_args->as<bool>("tty"));
-    fmt::print("- user: {}\n", exec_args->as<strv>("user"));
-    fmt::print("- workdir: {}\n", exec_args->as<strv>("workdir"));
-  } else if (auto const pull_args = args.cmd("pull")) {
-    fmt::print("\npull args:\n");
-    fmt::print("- name: {}\n", pull_args->as<strv>("name"));
-    fmt::print("- all-tags: {}\n", pull_args->as<bool>("all-tags"));
-    fmt::print("- disable-content-trust: {}\n", pull_args->as<bool>("disable-content-trust"));
-    fmt::print("- platform: {}\n", pull_args->as<strv>("platform"));
-    fmt::print("- quiet: {}\n", pull_args->as<bool>("quiet"));
-  }
+  // if (auto const exec_args = args.cmd("exec")) {
+  //   fmt::print("\nexec args:\n");
+  //   fmt::print("- container: {}\n", exec_args->as<strv>("container"));
+  //   fmt::print("- command: {}\n", exec_args->as<vec<strv>>("command"));
+  //   fmt::print("- detach: {}\n", exec_args->as<bool>("detach"));
+  //   fmt::print("- detach-keys: {}\n", exec_args->as<strv>("detach-keys"));
+  //   fmt::print("- env: {}\n", exec_args->as<vec<strv>>("env"));
+  //   fmt::print("- env-file: {}\n", exec_args->as<vec<strv>>("env-file"));
+  //   fmt::print("- interactive: {}\n", exec_args->as<bool>("interactive"));
+  //   fmt::print("- privileged: {}\n", exec_args->as<bool>("privileged"));
+  //   fmt::print("- tty: {}\n", exec_args->as<bool>("tty"));
+  //   fmt::print("- user: {}\n", exec_args->as<strv>("user"));
+  //   fmt::print("- workdir: {}\n", exec_args->as<strv>("workdir"));
+  // } else if (auto const pull_args = args.cmd("pull")) {
+  //   fmt::print("\npull args:\n");
+  //   fmt::print("- name: {}\n", pull_args->as<strv>("name"));
+  //   fmt::print("- all-tags: {}\n", pull_args->as<bool>("all-tags"));
+  //   fmt::print("- disable-content-trust: {}\n", pull_args->as<bool>("disable-content-trust"));
+  //   fmt::print("- platform: {}\n", pull_args->as<strv>("platform"));
+  //   fmt::print("- quiet: {}\n", pull_args->as<bool>("quiet"));
+  // }
 }

--- a/examples/docker.cpp
+++ b/examples/docker.cpp
@@ -45,7 +45,7 @@ int main(int argc, char const *argv[]) {
 
   auto const docker =
       Program("docker")
-          .v("version 20.10.1, build 831ebea")
+          .version("version 20.10.1, build 831ebea")
           .intro("A self-sufficient runtime for containers")
           .details("Run 'docker COMMAND --help' for more information on a command.") +
       Help() * Version() *

--- a/examples/docker.cpp
+++ b/examples/docker.cpp
@@ -23,86 +23,85 @@ using vec = std::vector<T>;
 int main(int argc, char const *argv[]) {
   using namespace opzioni;
 
-  constexpr auto exec = Program("exec").intro("Run a command in a running container") +
-                        Help() * Flg("detach", "d").help("Detached mode: run command in the background") *
-                            Opt("detach-keys").help("Override the key sequence for detaching a container") *
-                            Opt("env", "e").help("Set environment variables").append() *
-                            Opt("env-file").help("Read in a file of environment variables").append() *
-                            Flg("interactive", "i").help("Keep STDIN open even if not attached") *
-                            Flg("privileged").help("Give extended privileges to the command") *
-                            Flg("tty", "t").help("Allocate a pseudo-TTY") *
-                            Opt("user", "u").help("Username or UID (format: <name|uid>[:<group|gid>])") *
-                            Opt("workdir", "w").help("Working directory inside the container") *
-                            Pos("container").help("Name of the target container") *
-                            Pos("command").help("The command to run in the container").gather();
+  constexpr static auto exec = Program("exec").intro("Run a command in a running container") +
+                               Help() * Flg("detach", "d").help("Detached mode: run command in the background") *
+                                   Opt("detach-keys").help("Override the key sequence for detaching a container") *
+                                   Opt("env", "e").help("Set environment variables").append() *
+                                   Opt("env-file").help("Read in a file of environment variables").append() *
+                                   Flg("interactive", "i").help("Keep STDIN open even if not attached") *
+                                   Flg("privileged").help("Give extended privileges to the command") *
+                                   Flg("tty", "t").help("Allocate a pseudo-TTY") *
+                                   Opt("user", "u").help("Username or UID (format: <name|uid>[:<group|gid>])") *
+                                   Opt("workdir", "w").help("Working directory inside the container") *
+                                   Pos("container").help("Name of the target container") *
+                                   Pos("command").help("The command to run in the container").gather();
 
-  constexpr auto pull = Program("pull").intro("Pull an image or a repository from a registry") +
-                        Help() * Pos("name").help("The name of the image or repository to pull") *
-                            Flg("all-tags", "a").help("Download all tagged images in the repository") *
-                            Flg("disable-content-trust").help("Skip image verification") *
-                            Opt("platform").help("Set platform if server is multi-platform capable") *
-                            Flg("quiet", "q").help("Supress verbose output");
+  constexpr static auto pull = Program("pull").intro("Pull an image or a repository from a registry") +
+                               Help() * Pos("name").help("The name of the image or repository to pull") *
+                                   Flg("all-tags", "a").help("Download all tagged images in the repository") *
+                                   Flg("disable-content-trust").help("Skip image verification") *
+                                   Opt("platform").help("Set platform if server is multi-platform capable") *
+                                   Flg("quiet", "q").help("Supress verbose output");
 
-  constexpr auto commands = exec * pull;
-  // constexpr auto docker =
-  //     Program("docker")
-  //         .version("version 20.10.1, build 831ebea")
-  //         .intro("A self-sufficient runtime for containers")
-  //         .details("Run 'docker COMMAND --help' for more information on a command.") +
-  //     exec * pull * pull +
-  //     Help() * Version() *
-  //         Opt("config").help("Location of client config files (default {default_value})").otherwise("~/.docker") *
-  //         Opt("context", "c")
-  //             .help("Name of the context to use to connect to the daemon (overrides DOCKER_HOST env var and default "
-  //                   "context set with \"docker context use\")") *
-  //         Flg("debug", "D").help("Enable debug mode") *
-  //         Opt("host", "H").help("Daemon socket(s) to connect to").append() *
-  //         Opt("log-level", "l")
-  //             .help("Set the logging level (\"debug\"|\"info\"|\"warn\"|\"error\"|\"fatal\") (default {default_value})")
-  //             .otherwise("info") *
-  //         Flg("tls").help("Use TLS; implied by --tlsverify") *
-  //         Opt("tlscacert")
-  //             .help("Trust certs signed only by this CA (default {default_value})")
-  //             .otherwise("~/.docker/ca.pem") *
-  //         Opt("tlscert")
-  //             .help("Path to TLS certificate file (default {default_value})")
-  //             .otherwise("~/.docker/cert.pem") *
-  //         Opt("tlskey").help("Path to TLS key file (default {default_value})").otherwise("~/.docker/key.pem") *
-  //         Flg("tlsverify").help("Use TLS and verify the remote");
+  constexpr auto docker =
+      Program("docker")
+          .version("version 20.10.1, build 831ebea")
+          .intro("A self-sufficient runtime for containers")
+          .details("Run 'docker COMMAND --help' for more information on a command.") +
+      Help() * Version() *
+          Opt("config").help("Location of client config files (default {default_value})").otherwise("~/.docker") *
+          Opt("context", "c")
+              .help("Name of the context to use to connect to the daemon (overrides DOCKER_HOST env var and default "
+                    "context set with \"docker context use\")") *
+          Flg("debug", "D").help("Enable debug mode") *
+          Opt("host", "H").help("Daemon socket(s) to connect to").append() *
+          Opt("log-level", "l")
+              .help("Set the logging level (\"debug\"|\"info\"|\"warn\"|\"error\"|\"fatal\") (default {default_value})")
+              .otherwise("info") *
+          Flg("tls").help("Use TLS; implied by --tlsverify") *
+          Opt("tlscacert")
+              .help("Trust certs signed only by this CA (default {default_value})")
+              .otherwise("~/.docker/ca.pem") *
+          Opt("tlscert")
+              .help("Path to TLS certificate file (default {default_value})")
+              .otherwise("~/.docker/cert.pem") *
+          Opt("tlskey").help("Path to TLS key file (default {default_value})").otherwise("~/.docker/key.pem") *
+          Flg("tlsverify").help("Use TLS and verify the remote") +
+      exec * pull;
 
-  // auto const args = docker(argc, argv);
+  auto const args = docker(argc, argv);
 
-  // fmt::print("docker args:\n");
-  // fmt::print("- config: {}\n", args.as<strv>("config"));
-  // fmt::print("- context: {}\n", args.as<strv>("context"));
-  // fmt::print("- debug: {}\n", args.as<bool>("debug"));
-  // fmt::print("- host: {}\n", args.as<vec<strv>>("host"));
-  // fmt::print("- log-level: {}\n", args.as<strv>("log-level"));
-  // fmt::print("- tls: {}\n", args.as<bool>("tls"));
-  // fmt::print("- tlscacert: {}\n", args.as<strv>("tlscacert"));
-  // fmt::print("- tlscert: {}\n", args.as<strv>("tlscert"));
-  // fmt::print("- tlskey: {}\n", args.as<strv>("tlskey"));
-  // fmt::print("- tlsverify: {}\n", args.as<bool>("tlsverify"));
+  fmt::print("docker args:\n");
+  fmt::print("- config: {}\n", args.as<strv>("config"));
+  fmt::print("- context: {}\n", args.as<strv>("context"));
+  fmt::print("- debug: {}\n", args.as<bool>("debug"));
+  fmt::print("- host: {}\n", args.as<vec<strv>>("host"));
+  fmt::print("- log-level: {}\n", args.as<strv>("log-level"));
+  fmt::print("- tls: {}\n", args.as<bool>("tls"));
+  fmt::print("- tlscacert: {}\n", args.as<strv>("tlscacert"));
+  fmt::print("- tlscert: {}\n", args.as<strv>("tlscert"));
+  fmt::print("- tlskey: {}\n", args.as<strv>("tlskey"));
+  fmt::print("- tlsverify: {}\n", args.as<bool>("tlsverify"));
 
-  // if (auto const exec_args = args.cmd("exec")) {
-  //   fmt::print("\nexec args:\n");
-  //   fmt::print("- container: {}\n", exec_args->as<strv>("container"));
-  //   fmt::print("- command: {}\n", exec_args->as<vec<strv>>("command"));
-  //   fmt::print("- detach: {}\n", exec_args->as<bool>("detach"));
-  //   fmt::print("- detach-keys: {}\n", exec_args->as<strv>("detach-keys"));
-  //   fmt::print("- env: {}\n", exec_args->as<vec<strv>>("env"));
-  //   fmt::print("- env-file: {}\n", exec_args->as<vec<strv>>("env-file"));
-  //   fmt::print("- interactive: {}\n", exec_args->as<bool>("interactive"));
-  //   fmt::print("- privileged: {}\n", exec_args->as<bool>("privileged"));
-  //   fmt::print("- tty: {}\n", exec_args->as<bool>("tty"));
-  //   fmt::print("- user: {}\n", exec_args->as<strv>("user"));
-  //   fmt::print("- workdir: {}\n", exec_args->as<strv>("workdir"));
-  // } else if (auto const pull_args = args.cmd("pull")) {
-  //   fmt::print("\npull args:\n");
-  //   fmt::print("- name: {}\n", pull_args->as<strv>("name"));
-  //   fmt::print("- all-tags: {}\n", pull_args->as<bool>("all-tags"));
-  //   fmt::print("- disable-content-trust: {}\n", pull_args->as<bool>("disable-content-trust"));
-  //   fmt::print("- platform: {}\n", pull_args->as<strv>("platform"));
-  //   fmt::print("- quiet: {}\n", pull_args->as<bool>("quiet"));
-  // }
+  if (auto const exec_args = args.cmd("exec")) {
+    fmt::print("\nexec args:\n");
+    fmt::print("- container: {}\n", exec_args->as<strv>("container"));
+    fmt::print("- command: {}\n", exec_args->as<vec<strv>>("command"));
+    fmt::print("- detach: {}\n", exec_args->as<bool>("detach"));
+    fmt::print("- detach-keys: {}\n", exec_args->as<strv>("detach-keys"));
+    fmt::print("- env: {}\n", exec_args->as<vec<strv>>("env"));
+    fmt::print("- env-file: {}\n", exec_args->as<vec<strv>>("env-file"));
+    fmt::print("- interactive: {}\n", exec_args->as<bool>("interactive"));
+    fmt::print("- privileged: {}\n", exec_args->as<bool>("privileged"));
+    fmt::print("- tty: {}\n", exec_args->as<bool>("tty"));
+    fmt::print("- user: {}\n", exec_args->as<strv>("user"));
+    fmt::print("- workdir: {}\n", exec_args->as<strv>("workdir"));
+  } else if (auto const pull_args = args.cmd("pull")) {
+    fmt::print("\npull args:\n");
+    fmt::print("- name: {}\n", pull_args->as<strv>("name"));
+    fmt::print("- all-tags: {}\n", pull_args->as<bool>("all-tags"));
+    fmt::print("- disable-content-trust: {}\n", pull_args->as<bool>("disable-content-trust"));
+    fmt::print("- platform: {}\n", pull_args->as<strv>("platform"));
+    fmt::print("- quiet: {}\n", pull_args->as<bool>("quiet"));
+  }
 }

--- a/examples/gather.cpp
+++ b/examples/gather.cpp
@@ -11,7 +11,7 @@ int main(int argc, char const *argv[]) {
   using opzioni::Program, opzioni::ArgValue;
 
   auto const program =
-      Program("gather", "A short example file to illustrate the gather feature").v("1.0") +
+      Program("gather", "A short example file to illustrate the gather feature").version("1.0") +
       Help() * Version() *
           Pos("all")
               .help(

--- a/examples/gather.cpp
+++ b/examples/gather.cpp
@@ -10,7 +10,7 @@ int main(int argc, char const *argv[]) {
   using opzioni::Help, opzioni::Opt, opzioni::Pos, opzioni::Version;
   using opzioni::Program, opzioni::ArgValue;
 
-  auto const program =
+  constexpr auto program =
       Program("gather", "A short example file to illustrate the gather feature").version("1.0") +
       Help() * Version() *
           Pos("all")

--- a/examples/hello.cpp
+++ b/examples/hello.cpp
@@ -6,8 +6,8 @@
 int main(int argc, char const *argv[]) {
   using namespace opzioni;
 
-  auto const hello = Program("hello").version("0.1").intro("Greeting people since the dawn of computing") +
-                     Help() * Version() * Pos("name").help("Your name please, so I can greet you");
+  constexpr auto hello = Program("hello").version("0.1").intro("Greeting people since the dawn of computing") +
+                         Help() * Version() * Pos("name").help("Your name please, so I can greet you");
 
   auto const args = hello(argc, argv);
   std::string_view const name = args["name"];

--- a/examples/hello.cpp
+++ b/examples/hello.cpp
@@ -6,7 +6,7 @@
 int main(int argc, char const *argv[]) {
   using namespace opzioni;
 
-  auto const hello = Program("hello").v("0.1").intro("Greeting people since the dawn of computing") +
+  auto const hello = Program("hello").version("0.1").intro("Greeting people since the dawn of computing") +
                      Help() * Version() * Pos("name").help("Your name please, so I can greet you");
 
   auto const args = hello(argc, argv);

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -11,7 +11,7 @@ int main(int argc, char const *argv[]) {
   using opzioni::Help, opzioni::Version;
   using opzioni::Program, opzioni::Flg, opzioni::Opt, opzioni::Pos;
 
-  auto const program =
+  constexpr auto program =
       Program("main")
           .version("1.0")
           .intro("A short example illustrating opzioni's simpler features")

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -13,7 +13,7 @@ int main(int argc, char const *argv[]) {
 
   auto const program =
       Program("main")
-          .v("1.0")
+          .version("1.0")
           .intro("A short example illustrating opzioni's simpler features")
           .details("This example only covers simple positionals, options, and flags. For examples of more"
                    " complicated parse actions or subcommands, please take a look at the other examples.") +

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -474,13 +474,16 @@ public:
   consteval Program(std::string_view name) : Program(name, {}) {}
   consteval Program(std::string_view name, std::string_view title) : metadata(name, title) {}
 
-  consteval Program(ProgramView const &other) : metadata(other.metadata) {
-    if constexpr (ArgsSize > 0)
-      if (other.args.size() > 0)
-        std::copy_n(other.args.begin(), ArgsSize, args.begin());
-    if constexpr (CmdsSize > 0)
-      if (other.args.size() > 0)
-        std::copy_n(other.cmds.begin(), CmdsSize, cmds.begin());
+  template <std::size_t OtherArgsSize, std::size_t OtherCmdsSize>
+  consteval Program(Program<OtherArgsSize, OtherCmdsSize> const &other) : metadata(other.metadata) {
+    static_assert(ArgsSize >= OtherArgsSize,
+                  "attempting to copy-construct a Program from another that has more args than the new one could hold");
+    static_assert(CmdsSize >= OtherCmdsSize,
+                  "attempting to copy-construct a Program from another that has more cmds than the new one could hold");
+    for (std::size_t i = 0; i < OtherArgsSize; ++i)
+      args[i] = other.args[i];
+    for (std::size_t i = 0; i < OtherCmdsSize; ++i)
+      cmds[i] = other.cmds[i];
   }
 
   consteval auto intro(std::string_view introduction) const noexcept {

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -430,6 +430,7 @@ struct ProgramMetadata {
 
   std::size_t msg_width = 100;
   std::size_t positionals_amount = 0;
+  ErrorHandler error_handler = print_error;
 };
 
 struct ProgramView {
@@ -441,7 +442,6 @@ struct ProgramView {
 class Program {
 public:
   ProgramMetadata metadata{};
-  ErrorHandler error_handler = print_error;
 
   Program() = default;
   Program(std::string_view name) : Program(name, {}) {}

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -562,8 +562,6 @@ public:
     try {
       return parse(*this, args);
     } catch (UserError const &err) {
-      if (this->metadata.error_handler == nullptr)
-        std::exit(-1);
       std::exit(this->metadata.error_handler(*this, err));
     }
   }

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -492,7 +492,7 @@ public:
 
   bool has_cmd(std::string_view name) const noexcept { return find_cmd(name) != _cmds.end(); }
 
-  operator ProgramView() const noexcept { return ProgramView(this->metadata, this->_args, this->_cmds); }
+  constexpr operator ProgramView() const noexcept { return ProgramView(this->metadata, this->_args, this->_cmds); }
 
 private:
   std::vector<Arg> _args;

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -412,8 +412,8 @@ ArgMap parse(ProgramView const program, std::span<char const *> args);
 
 struct ProgramMetadata {
   std::string_view name{};
-  std::string_view version{};
   std::string_view title{};
+  std::string_view version{};
   std::string_view introduction{};
   std::string_view description{};
 
@@ -472,7 +472,7 @@ public:
 
   consteval Program() = default;
   consteval Program(std::string_view name) : Program(name, {}) {}
-  consteval Program(std::string_view name, std::string_view title) : metadata(name, title) {}
+  consteval Program(std::string_view name, std::string_view title) : metadata{.name = name, .title = title} {}
 
   template <std::size_t OtherArgsSize, std::size_t OtherCmdsSize>
   consteval Program(Program<OtherArgsSize, OtherCmdsSize> const &other) : metadata(other.metadata) {

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -415,7 +415,7 @@ struct ParsedOption {
   std::optional<std::string_view> value;
 };
 
-ParsedOption parse_option(std::string_view const) noexcept;
+constexpr ParsedOption parse_option(std::string_view const) noexcept;
 
 // +---------+
 // | Program |
@@ -511,13 +511,13 @@ constexpr bool has_cmd(ProgramView const program, std::string_view name) noexcep
 // | parsing helpers |
 // +-----------------+
 
-bool is_dash_dash(std::string_view const) noexcept;
-Cmd const *is_command(ProgramView const, std::string_view const) noexcept;
-bool looks_positional(std::string_view const) noexcept;
-std::string_view is_short_flags(ProgramView const, std::string_view const) noexcept;
-std::string_view is_long_flag(ProgramView const, std::string_view const) noexcept;
-std::optional<ParsedOption> is_option(ProgramView const, std::string_view const) noexcept;
-bool is_flag(ProgramView const, std::string_view const) noexcept;
+constexpr bool is_dash_dash(std::string_view const) noexcept;
+constexpr Cmd const *is_command(ProgramView const, std::string_view const) noexcept;
+constexpr bool looks_positional(std::string_view const) noexcept;
+constexpr std::string_view is_short_flags(ProgramView const, std::string_view const) noexcept;
+constexpr std::string_view is_long_flag(ProgramView const, std::string_view const) noexcept;
+constexpr std::optional<ParsedOption> is_option(ProgramView const, std::string_view const) noexcept;
+constexpr bool is_flag(ProgramView const, std::string_view const) noexcept;
 
 // +-----------+
 // | utilities |

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -428,9 +428,14 @@ struct ProgramMetadata {
 };
 
 struct ProgramView {
-  ProgramMetadata metadata;
-  std::span<Arg const> args;
-  std::span<ProgramView const> cmds;
+  ProgramMetadata metadata{};
+  Arg const *args_begin = nullptr;
+  std::size_t args_size = 0;
+  ProgramView const *cmds_begin = nullptr;
+  std::size_t cmds_size = 0;
+
+  constexpr auto args() const noexcept { return std::span<Arg const>(args_begin, args_size); }
+  constexpr auto cmds() const noexcept { return std::span<ProgramView const>(cmds_begin, cmds_size); }
 
   std::string format_for_help_description() const noexcept;
   std::string format_for_help_index() const noexcept;
@@ -556,7 +561,9 @@ public:
     return newprogram;
   }
 
-  constexpr operator ProgramView() const noexcept { return ProgramView(this->metadata, this->args, this->cmds); }
+  constexpr operator ProgramView() const noexcept {
+    return ProgramView(this->metadata, this->args.data(), this->args.size(), this->cmds.data(), this->cmds.size());
+  }
 
   ArgMap operator()(std::span<char const *> args) const {
     try {

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -487,8 +487,6 @@ private:
   ArgMap parse(std::span<char const *>) const;
   void check_contains_required(ArgMap const &) const;
   void set_defaults(ArgMap &) const noexcept;
-
-  std::size_t assign_option(ArgMap &, std::span<char const *>, ParsedOption const) const;
 };
 
 // +--------------------+
@@ -519,6 +517,7 @@ std::size_t assign_command(ArgMap &, std::span<char const *>, Cmd const &);
 std::size_t assign_positional(ProgramView const, ArgMap &, std::span<char const *>, std::size_t const);
 std::size_t assign_many_flags(ProgramView const, ArgMap &, std::string_view);
 std::size_t assign_flag(ProgramView const, ArgMap &, std::string_view);
+std::size_t assign_option(ProgramView const, ArgMap &, std::span<char const *>, ParsedOption const);
 
 // +-----------+
 // | utilities |

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -449,7 +449,7 @@ public:
 
   Program &intro(std::string_view) noexcept;
   Program &details(std::string_view) noexcept;
-  Program &v(std::string_view) noexcept; // I don't know what else to call this
+  Program &version(std::string_view) noexcept; // I don't know what else to call this
 
   Program &max_width(std::size_t) noexcept;
   Program &on_error(ErrorHandler) noexcept;

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -544,7 +544,7 @@ public:
 
   constexpr operator ProgramView() const noexcept { return ProgramView(this->metadata, this->args, this->cmds); }
 
-  ArgMap operator()(std::span<char const *> args) const noexcept {
+  ArgMap operator()(std::span<char const *> args) const {
     try {
       return parse(*this, args);
     } catch (UserError const &err) {
@@ -554,7 +554,7 @@ public:
     }
   }
 
-  ArgMap operator()(int argc, char const *argv[]) const noexcept {
+  ArgMap operator()(int argc, char const *argv[]) const {
     return (*this)(std::span<char const *>{argv, static_cast<std::size_t>(argc)});
   }
 };

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -512,7 +512,7 @@ private:
 };
 
 struct ProgramView {
-  ProgramMetadata const metadata;
+  ProgramMetadata const &metadata;
   std::span<Arg const> args;
   std::span<Cmd const> cmds;
 

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -460,14 +460,6 @@ constexpr bool operator==(ProgramView const &lhs, ProgramView const &rhs) noexce
   return lhs.metadata.name == rhs.metadata.name;
 }
 
-// struct Cmd {
-//   ProgramView program;
-
-//   consteval Cmd() = default;
-//   consteval Cmd(Cmd const &other) : program(other.program) {}
-//   consteval Cmd(ProgramView program) : program(program) {}
-// };
-
 consteval auto operator*(ProgramView const lhs, ProgramView const rhs) noexcept {
   if (lhs == rhs)
     throw "Trying to add command with a duplicate name";

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -431,6 +431,12 @@ struct ProgramMetadata {
   std::size_t positionals_amount = 0;
 };
 
+struct ProgramView {
+  ProgramMetadata const &metadata;
+  std::span<Arg const> args;
+  std::span<Cmd const> cmds;
+};
+
 class Program {
 public:
   ProgramMetadata metadata{};
@@ -485,6 +491,8 @@ public:
 
   bool has_cmd(std::string_view name) const noexcept { return find_cmd(name) != _cmds.end(); }
 
+  operator ProgramView() const noexcept { return ProgramView(this->metadata, this->_args, this->_cmds); }
+
 private:
   std::vector<Arg> _args;
   std::vector<Cmd> _cmds;
@@ -509,14 +517,6 @@ private:
   std::size_t assign_many_flags(ArgMap &, std::string_view) const;
   std::size_t assign_flag(ArgMap &, std::string_view) const;
   std::size_t assign_option(ArgMap &, std::span<char const *>, ParsedOption const) const;
-};
-
-struct ProgramView {
-  ProgramMetadata const &metadata;
-  std::span<Arg const> args;
-  std::span<Cmd const> cmds;
-
-  ProgramView(Program const &program) : metadata(program.metadata), args(program.args()), cmds(program.cmds()) {}
 };
 
 // +-----------+

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -488,7 +488,6 @@ private:
   void check_contains_required(ArgMap const &) const;
   void set_defaults(ArgMap &) const noexcept;
 
-  std::size_t assign_command(ArgMap &, std::span<char const *>, Cmd const &) const;
   std::size_t assign_many_flags(ArgMap &, std::string_view) const;
   std::size_t assign_flag(ArgMap &, std::string_view) const;
   std::size_t assign_option(ArgMap &, std::span<char const *>, ParsedOption const) const;
@@ -518,6 +517,7 @@ constexpr std::string_view is_long_flag(ProgramView const, std::string_view cons
 constexpr std::optional<ParsedOption> is_option(ProgramView const, std::string_view const) noexcept;
 constexpr bool is_flag(ProgramView const, std::string_view const) noexcept;
 
+std::size_t assign_command(ArgMap &, std::span<char const *>, Cmd const &);
 std::size_t assign_positional(ProgramView const, ArgMap &, std::span<char const *>, std::size_t const);
 
 // +-----------+

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -548,9 +548,8 @@ public:
   template <std::size_t N>
   consteval Program<ArgsSize, N> operator+(std::array<ProgramView, N> cmds) const noexcept {
     Program<ArgsSize, N> newprogram(*this);
-    for (std::size_t i = 0; i < N; ++i)
-      newprogram.cmds[i] = cmds[i];
-    std::sort(newprogram.cmds.begin(), newprogram.cmds.end());
+    std::ranges::copy(cmds, newprogram.cmds.begin());
+    std::sort(newprogram.cmds.begin(), newprogram.cmds.end()); // don't know why can't use std::ranges::sort
     return newprogram;
   }
 

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -449,7 +449,7 @@ public:
 
   Program &intro(std::string_view) noexcept;
   Program &details(std::string_view) noexcept;
-  Program &version(std::string_view) noexcept; // I don't know what else to call this
+  Program &version(std::string_view) noexcept;
 
   Program &max_width(std::size_t) noexcept;
   Program &on_error(ErrorHandler) noexcept;

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -470,8 +470,8 @@ consteval auto operator*(std::array<ProgramView, N> const cmds, ProgramView cons
 }
 
 template <std::size_t N>
-consteval void validate_cmds(std::array<ProgramView, N> const &args, ProgramView const &other) noexcept {
-  if (std::ranges::find(args, other) != args.end())
+consteval void validate_cmds(std::array<ProgramView, N> const &cmds, ProgramView const &other) noexcept {
+  if (std::ranges::find(cmds, other) != cmds.end())
     throw "Trying to add command with a duplicate name";
 }
 

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -507,10 +507,8 @@ public:
                   "attempting to copy-construct a Program from another that has more args than the new one could hold");
     static_assert(CmdsSize >= OtherCmdsSize,
                   "attempting to copy-construct a Program from another that has more cmds than the new one could hold");
-    for (std::size_t i = 0; i < OtherArgsSize; ++i)
-      args[i] = other.args[i];
-    for (std::size_t i = 0; i < OtherCmdsSize; ++i)
-      cmds[i] = other.cmds[i];
+    std::copy_n(other.args.begin(), OtherArgsSize, args.begin()); // don't know why std::ranges::copy_n doesn't work
+    std::copy_n(other.cmds.begin(), OtherCmdsSize, cmds.begin()); // don't know why std::ranges::copy_n doesn't work
   }
 
   consteval auto intro(std::string_view introduction) const noexcept {

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -488,8 +488,6 @@ private:
   void check_contains_required(ArgMap const &) const;
   void set_defaults(ArgMap &) const noexcept;
 
-  std::size_t assign_many_flags(ArgMap &, std::string_view) const;
-  std::size_t assign_flag(ArgMap &, std::string_view) const;
   std::size_t assign_option(ArgMap &, std::span<char const *>, ParsedOption const) const;
 };
 
@@ -519,6 +517,8 @@ constexpr bool is_flag(ProgramView const, std::string_view const) noexcept;
 
 std::size_t assign_command(ArgMap &, std::span<char const *>, Cmd const &);
 std::size_t assign_positional(ProgramView const, ArgMap &, std::span<char const *>, std::size_t const);
+std::size_t assign_many_flags(ProgramView const, ArgMap &, std::string_view);
+std::size_t assign_flag(ProgramView const, ArgMap &, std::string_view);
 
 // +-----------+
 // | utilities |

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -483,10 +483,9 @@ private:
 
   Program &add(Arg);
   Program &add(Cmd);
-
-  ArgMap parse(std::span<char const *>) const;
 };
 
+ArgMap parse(ProgramView const, std::span<char const *>);
 void check_contains_required(ProgramView const, ArgMap const &);
 void set_defaults(ProgramView const, ArgMap &) noexcept;
 

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -523,6 +523,9 @@ public:
   }
 
   consteval auto on_error(ErrorHandler error_handler) const noexcept {
+    if (error_handler == nullptr)
+      throw "A program or command must have an error handler. If you don't want the"
+            "default try... catch behavior, just use parse(ProgramView const, std::span<char const *>)";
     auto program = *this;
     program.metadata.error_handler = error_handler;
     return program;

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -469,8 +469,8 @@ public:
     return *this;
   }
 
-  ArgMap operator()(int, char const *[]) const;
-  ArgMap operator()(std::span<char const *>) const;
+  ArgMap operator()(int, char const *[]) const noexcept;
+  ArgMap operator()(std::span<char const *>) const noexcept;
 
   std::vector<Arg> const &args() const noexcept { return _args; }
   std::vector<Cmd> const &cmds() const noexcept { return _cmds; }
@@ -485,9 +485,7 @@ private:
   Program &add(Cmd);
 };
 
-ArgMap parse(ProgramView const, std::span<char const *>);
-void check_contains_required(ProgramView const, ArgMap const &);
-void set_defaults(ProgramView const, ArgMap &) noexcept;
+ArgMap parse(ProgramView const program, std::span<char const *> args);
 
 // +--------------------+
 // | arg and cmd search |

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -485,9 +485,10 @@ private:
   Program &add(Cmd);
 
   ArgMap parse(std::span<char const *>) const;
-  void check_contains_required(ArgMap const &) const;
-  void set_defaults(ArgMap &) const noexcept;
 };
+
+void check_contains_required(ProgramView const, ArgMap const &);
+void set_defaults(ProgramView const, ArgMap &) noexcept;
 
 // +--------------------+
 // | arg and cmd search |

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -427,12 +427,16 @@ struct ProgramMetadata {
   constexpr auto operator<=>(ProgramMetadata const &) const noexcept = default;
 };
 
-struct ProgramView {
+class ProgramView {
+public:
   ProgramMetadata metadata{};
-  Arg const *args_begin = nullptr;
-  std::size_t args_size = 0;
-  ProgramView const *cmds_begin = nullptr;
-  std::size_t cmds_size = 0;
+
+  constexpr ProgramView() = default;
+
+  constexpr ProgramView(ProgramMetadata metadata, Arg const *args_begin, std::size_t args_size,
+                        ProgramView const *cmds_begin, std::size_t cmds_size)
+      : metadata(metadata), args_begin(args_begin), args_size(args_size), cmds_begin(cmds_begin), cmds_size(cmds_size) {
+  }
 
   constexpr auto args() const noexcept { return std::span<Arg const>(args_begin, args_size); }
   constexpr auto cmds() const noexcept { return std::span<ProgramView const>(cmds_begin, cmds_size); }
@@ -440,6 +444,12 @@ struct ProgramView {
   std::string format_for_help_description() const noexcept;
   std::string format_for_help_index() const noexcept;
   std::string format_for_usage_summary() const noexcept;
+
+private:
+  Arg const *args_begin = nullptr;
+  std::size_t args_size = 0;
+  ProgramView const *cmds_begin = nullptr;
+  std::size_t cmds_size = 0;
 };
 
 constexpr bool operator<(ProgramView const &lhs, ProgramView const &rhs) noexcept {

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -489,7 +489,6 @@ private:
   void set_defaults(ArgMap &) const noexcept;
 
   std::size_t assign_command(ArgMap &, std::span<char const *>, Cmd const &) const;
-  std::size_t assign_positional(ArgMap &, std::span<char const *>, std::size_t const) const;
   std::size_t assign_many_flags(ArgMap &, std::string_view) const;
   std::size_t assign_flag(ArgMap &, std::string_view) const;
   std::size_t assign_option(ArgMap &, std::span<char const *>, ParsedOption const) const;
@@ -518,6 +517,8 @@ constexpr std::string_view is_short_flags(ProgramView const, std::string_view co
 constexpr std::string_view is_long_flag(ProgramView const, std::string_view const) noexcept;
 constexpr std::optional<ParsedOption> is_option(ProgramView const, std::string_view const) noexcept;
 constexpr bool is_flag(ProgramView const, std::string_view const) noexcept;
+
+std::size_t assign_positional(ProgramView const, ArgMap &, std::span<char const *>, std::size_t const);
 
 // +-----------+
 // | utilities |

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -475,23 +475,6 @@ public:
   std::vector<Arg> const &args() const noexcept { return _args; }
   std::vector<Cmd> const &cmds() const noexcept { return _cmds; }
 
-  constexpr auto find_arg(std::string_view name, ArgType type) const noexcept {
-    return std::ranges::find_if(_args, [name, type](auto const &arg) {
-      return arg.type == type && (arg.name == name || (arg.has_abbrev() && arg.abbrev == name));
-    });
-  }
-
-  bool has_arg(std::string_view name, ArgType type) const noexcept { return find_arg(name, type) != _args.end(); }
-  bool has_flg(std::string_view name) const noexcept { return has_arg(name, ArgType::FLG); }
-  bool has_opt(std::string_view name) const noexcept { return has_arg(name, ArgType::OPT); }
-  bool has_pos(std::string_view name) const noexcept { return has_arg(name, ArgType::POS); }
-
-  constexpr auto find_cmd(std::string_view name) const noexcept {
-    return std::ranges::find(_cmds, name, [](auto const &cmd) { return cmd.program->metadata.name; });
-  }
-
-  bool has_cmd(std::string_view name) const noexcept { return find_cmd(name) != _cmds.end(); }
-
   constexpr operator ProgramView() const noexcept { return ProgramView(this->metadata, this->_args, this->_cmds); }
 
 private:
@@ -505,20 +488,36 @@ private:
   void check_contains_required(ArgMap const &) const;
   void set_defaults(ArgMap &) const noexcept;
 
-  bool is_dash_dash(std::string_view const) const noexcept;
-  Cmd const *is_command(std::string_view const) const noexcept;
-  bool looks_positional(std::string_view const) const noexcept;
-  std::string_view is_short_flags(std::string_view const) const noexcept;
-  std::string_view is_long_flag(std::string_view const) const noexcept;
-  std::optional<ParsedOption> is_option(std::string_view const) const noexcept;
-  bool is_flag(std::string_view const) const noexcept;
-
   std::size_t assign_command(ArgMap &, std::span<char const *>, Cmd const &) const;
   std::size_t assign_positional(ArgMap &, std::span<char const *>, std::size_t const) const;
   std::size_t assign_many_flags(ArgMap &, std::string_view) const;
   std::size_t assign_flag(ArgMap &, std::string_view) const;
   std::size_t assign_option(ArgMap &, std::span<char const *>, ParsedOption const) const;
 };
+
+// +--------------------+
+// | arg and cmd search |
+// +--------------------+
+
+constexpr auto find_arg(ProgramView const program, std::string_view name, ArgType type) noexcept;
+constexpr bool has_arg(ProgramView const program, std::string_view name, ArgType type) noexcept;
+constexpr bool has_flg(ProgramView const program, std::string_view name) noexcept;
+constexpr bool has_opt(ProgramView const program, std::string_view name) noexcept;
+constexpr bool has_pos(ProgramView const program, std::string_view name) noexcept;
+constexpr auto find_cmd(ProgramView const program, std::string_view name) noexcept;
+constexpr bool has_cmd(ProgramView const program, std::string_view name) noexcept;
+
+// +-----------------+
+// | parsing helpers |
+// +-----------------+
+
+bool is_dash_dash(std::string_view const) noexcept;
+Cmd const *is_command(ProgramView const, std::string_view const) noexcept;
+bool looks_positional(std::string_view const) noexcept;
+std::string_view is_short_flags(ProgramView const, std::string_view const) noexcept;
+std::string_view is_long_flag(ProgramView const, std::string_view const) noexcept;
+std::optional<ParsedOption> is_option(ProgramView const, std::string_view const) noexcept;
+bool is_flag(ProgramView const, std::string_view const) noexcept;
 
 // +-----------+
 // | utilities |

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -422,7 +422,7 @@ struct ProgramMetadata {
 
   std::size_t msg_width = 100;
   std::size_t positionals_amount = 0;
-  ErrorHandler error_handler = print_error;
+  ErrorHandler error_handler = print_error_and_usage;
 
   constexpr auto operator<=>(ProgramMetadata const &) const noexcept = default;
 };

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -399,19 +399,27 @@ consteval Arg Version(std::string_view description) noexcept {
 
 consteval Arg Version() noexcept { return Version("Display the software version"); }
 
-struct ParsedOption {
-  std::string_view name;
-  // no string and empty string mean different things here
-  std::optional<std::string_view> value;
-};
+// +--------------------+
+// | arg and cmd search |
+// +--------------------+
 
-constexpr ParsedOption parse_option(std::string_view const) noexcept;
+constexpr auto find_arg(ProgramView const program, std::string_view name, ArgType type) noexcept;
+constexpr bool has_arg(ProgramView const program, std::string_view name, ArgType type) noexcept;
+constexpr bool has_flg(ProgramView const program, std::string_view name) noexcept;
+constexpr bool has_opt(ProgramView const program, std::string_view name) noexcept;
+constexpr bool has_pos(ProgramView const program, std::string_view name) noexcept;
+constexpr auto find_cmd(ProgramView const program, std::string_view name) noexcept;
+constexpr bool has_cmd(ProgramView const program, std::string_view name) noexcept;
 
 // +---------+
-// | Program |
+// | parsing |
 // +---------+
 
 ArgMap parse(ProgramView const program, std::span<char const *> args);
+
+// +-----------------+
+// | ProgramMetadata |
+// +-----------------+
 
 struct ProgramMetadata {
   std::string_view name{};
@@ -426,6 +434,10 @@ struct ProgramMetadata {
 
   constexpr auto operator<=>(ProgramMetadata const &) const noexcept = default;
 };
+
+// +-------------+
+// | ProgramView |
+// +-------------+
 
 class ProgramView {
 public:
@@ -481,6 +493,10 @@ consteval void validate_cmds(std::array<ProgramView, N> const &cmds, ProgramView
   if (std::ranges::find(cmds, other) != cmds.end())
     throw "Trying to add command with a duplicate name";
 }
+
+// +---------+
+// | Program |
+// +---------+
 
 template <std::size_t ArgsSize, std::size_t CmdsSize>
 class Program {
@@ -579,36 +595,6 @@ public:
 
 private:
 };
-
-// +--------------------+
-// | arg and cmd search |
-// +--------------------+
-
-constexpr auto find_arg(ProgramView const program, std::string_view name, ArgType type) noexcept;
-constexpr bool has_arg(ProgramView const program, std::string_view name, ArgType type) noexcept;
-constexpr bool has_flg(ProgramView const program, std::string_view name) noexcept;
-constexpr bool has_opt(ProgramView const program, std::string_view name) noexcept;
-constexpr bool has_pos(ProgramView const program, std::string_view name) noexcept;
-constexpr auto find_cmd(ProgramView const program, std::string_view name) noexcept;
-constexpr bool has_cmd(ProgramView const program, std::string_view name) noexcept;
-
-// +-----------------+
-// | parsing helpers |
-// +-----------------+
-
-constexpr bool is_dash_dash(std::string_view const) noexcept;
-constexpr ProgramView const *is_command(ProgramView const, std::string_view const) noexcept;
-constexpr bool looks_positional(std::string_view const) noexcept;
-constexpr std::string_view is_short_flags(ProgramView const, std::string_view const) noexcept;
-constexpr std::string_view is_long_flag(ProgramView const, std::string_view const) noexcept;
-constexpr std::optional<ParsedOption> is_option(ProgramView const, std::string_view const) noexcept;
-constexpr bool is_flag(ProgramView const, std::string_view const) noexcept;
-
-std::size_t assign_command(ArgMap &, std::span<char const *>, ProgramView const);
-std::size_t assign_positional(ProgramView const, ArgMap &, std::span<char const *>, std::size_t const);
-std::size_t assign_many_flags(ProgramView const, ArgMap &, std::string_view);
-std::size_t assign_flag(ProgramView const, ArgMap &, std::string_view);
-std::size_t assign_option(ProgramView const, ArgMap &, std::span<char const *>, ParsedOption const);
 
 // +-----------+
 // | utilities |

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -568,6 +568,8 @@ public:
   ArgMap operator()(int argc, char const *argv[]) const {
     return (*this)(std::span<char const *>{argv, static_cast<std::size_t>(argc)});
   }
+
+private:
 };
 
 // +--------------------+

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -35,6 +35,7 @@ std::string builtin2str(BuiltinVariant const &) noexcept;
 struct Arg;
 struct ArgMap;
 class Program;
+struct ProgramView;
 
 consteval void validate_arg(Arg const &) noexcept;
 
@@ -44,31 +45,31 @@ consteval void validate_args(std::array<Arg, N> const &, Arg const &) noexcept;
 // +----------------+
 // | error handlers |
 // +----------------+
-using ErrorHandler = int (*)(Program const &, UserError const &);
+using ErrorHandler = int (*)(ProgramView const, UserError const &);
 
-int print_error(Program const &, UserError const &) noexcept;
-int print_error_and_usage(Program const &, UserError const &) noexcept;
-int rethrow(Program const &, UserError const &);
+int print_error(ProgramView const, UserError const &) noexcept;
+int print_error_and_usage(ProgramView const, UserError const &) noexcept;
+int rethrow(ProgramView const, UserError const &);
 
 // +---------+
 // | actions |
 // +---------+
 namespace actions {
 
-using Signature = void (*)(Program const &, ArgMap &, Arg const &, std::optional<std::string_view> const);
+using Signature = void (*)(ProgramView const, ArgMap &, Arg const &, std::optional<std::string_view> const);
 
 template <concepts::BuiltinType T>
-void assign(Program const &, ArgMap &, Arg const &, std::optional<std::string_view> const);
+void assign(ProgramView const, ArgMap &, Arg const &, std::optional<std::string_view> const);
 
 template <concepts::BuiltinType Elem>
-void append(Program const &, ArgMap &, Arg const &, std::optional<std::string_view> const);
+void append(ProgramView const, ArgMap &, Arg const &, std::optional<std::string_view> const);
 
 template <concepts::BuiltinType Elem>
-void csv(Program const &, ArgMap &, Arg const &, std::optional<std::string_view> const);
+void csv(ProgramView const, ArgMap &, Arg const &, std::optional<std::string_view> const);
 
-void print_help(Program const &, ArgMap &, Arg const &, std::optional<std::string_view> const);
+void print_help(ProgramView const, ArgMap &, Arg const &, std::optional<std::string_view> const);
 
-void print_version(Program const &, ArgMap &, Arg const &, std::optional<std::string_view> const);
+void print_version(ProgramView const, ArgMap &, Arg const &, std::optional<std::string_view> const);
 
 } // namespace actions
 
@@ -523,7 +524,7 @@ private:
 // | utilities |
 // +-----------+
 
-void print_full_help(Program const &, std::ostream & = std::cout) noexcept;
+void print_full_help(ProgramView const, std::ostream & = std::cout) noexcept;
 
 // +------------+
 // | formatting |
@@ -580,7 +581,7 @@ void assign_to(ArgMap &map, std::string_view const name, T value) {
 }
 
 template <concepts::BuiltinType T>
-void assign(Program const &, ArgMap &map, Arg const &arg, std::optional<std::string_view> const parsed_value) {
+void assign(ProgramView const, ArgMap &map, Arg const &arg, std::optional<std::string_view> const parsed_value) {
   if (arg.type != ArgType::FLG && parsed_value)
     assign_to(map, arg.name, convert<T>(*parsed_value));
   else
@@ -601,7 +602,7 @@ void append_to(ArgMap &map, std::string_view const name, Elem value) {
 }
 
 template <concepts::BuiltinType Elem>
-void append(Program const &, ArgMap &map, Arg const &arg, std::optional<std::string_view> const parsed_value) {
+void append(ProgramView const, ArgMap &map, Arg const &arg, std::optional<std::string_view> const parsed_value) {
   if (arg.type != ArgType::FLG && parsed_value)
     append_to<Elem>(map, arg.name, convert<Elem>(*parsed_value));
   else
@@ -613,7 +614,7 @@ void append(Program const &, ArgMap &map, Arg const &arg, std::optional<std::str
 // +-----+
 
 template <concepts::BuiltinType Elem>
-void csv(Program const &, ArgMap &map, Arg const &arg, std::optional<std::string_view> const parsed_value) {
+void csv(ProgramView const, ArgMap &map, Arg const &arg, std::optional<std::string_view> const parsed_value) {
   assign_to(map, arg.name, convert<std::vector<Elem>>(*parsed_value));
 }
 

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -526,7 +526,7 @@ public:
         std::ranges::copy_n(positionals.begin(), newprogram.metadata.positionals_amount, newprogram.args.begin());
     std::ranges::copy_n(others.begin(), N - newprogram.metadata.positionals_amount, copy_result.out);
 
-    // std::ranges::sort(copy_result.out, newprogram.args.end());
+    std::sort(copy_result.out, newprogram.args.end());
     return newprogram;
   }
 

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -317,7 +317,7 @@ consteval auto operator*(Arg const lhs, Arg const rhs) noexcept {
     throw "Trying to add argument with a duplicate name";
   validate_arg(lhs);
   validate_arg(rhs);
-  return std::array<Arg, 2>{lhs, rhs};
+  return std::array{lhs, rhs};
 }
 
 template <std::size_t N>

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project(
     'opzioni', 'cpp',
-    version: '0.43.0',
+    version: '0.44.0',
     license: 'BSL-1.0',
     default_options: ['cpp_std=c++2a', 'buildtype=debug']
 )

--- a/src/opzioni.cpp
+++ b/src/opzioni.cpp
@@ -14,12 +14,12 @@ std::string builtin2str(BuiltinVariant const &variant) noexcept {
   return std::visit(_2str, variant);
 }
 
-int print_error(Program const &program, UserError const &err) noexcept {
+int print_error(ProgramView const program, UserError const &err) noexcept {
   std::cerr << limit_string_within(err.what(), program.metadata.msg_width) << nl;
   return -1;
 }
 
-int print_error_and_usage(Program const &program, UserError const &err) noexcept {
+int print_error_and_usage(ProgramView const program, UserError const &err) noexcept {
   print_error(program, err);
   HelpFormatter formatter(program, std::cerr);
   std::cerr << nl;
@@ -27,7 +27,7 @@ int print_error_and_usage(Program const &program, UserError const &err) noexcept
   return -1;
 }
 
-int rethrow(Program const &, UserError const &ue) { throw ue; }
+int rethrow(ProgramView const, UserError const &ue) { throw ue; }
 
 // +-----+
 // | Arg |
@@ -465,7 +465,7 @@ void HelpFormatter::print_description() const noexcept {
 // | utilities |
 // +-----------+
 
-void print_full_help(Program const &program, std::ostream &ostream) noexcept {
+void print_full_help(ProgramView const program, std::ostream &ostream) noexcept {
   HelpFormatter formatter(program, ostream);
   formatter.print_title();
   if (!program.metadata.introduction.empty()) {
@@ -486,12 +486,12 @@ void print_full_help(Program const &program, std::ostream &ostream) noexcept {
 
 namespace actions {
 
-void print_help(Program const &program, ArgMap &, Arg const &, std::optional<std::string_view> const) {
+void print_help(ProgramView const program, ArgMap &, Arg const &, std::optional<std::string_view> const) {
   print_full_help(program);
   std::exit(0);
 }
 
-void print_version(Program const &program, ArgMap &, Arg const &, std::optional<std::string_view> const) {
+void print_version(ProgramView const program, ArgMap &, Arg const &, std::optional<std::string_view> const) {
   fmt::print("{} {}\n", program.metadata.name, program.metadata.version);
   std::exit(0);
 }

--- a/src/opzioni.cpp
+++ b/src/opzioni.cpp
@@ -110,7 +110,7 @@ Program &Program::details(std::string_view description) noexcept {
   return *this;
 }
 
-Program &Program::v(std::string_view version) noexcept {
+Program &Program::version(std::string_view version) noexcept {
   this->metadata.version = version;
   return *this;
 }

--- a/src/opzioni.cpp
+++ b/src/opzioni.cpp
@@ -121,7 +121,7 @@ Program &Program::max_width(std::size_t msg_width) noexcept {
 }
 
 Program &Program::on_error(ErrorHandler error_handler) noexcept {
-  this->error_handler = error_handler;
+  this->metadata.error_handler = error_handler;
   return *this;
 }
 
@@ -149,9 +149,9 @@ ArgMap Program::operator()(std::span<char const *> args) const {
     set_defaults(*this, map);
     return map;
   } catch (UserError const &err) {
-    if (this->error_handler == nullptr)
+    if (this->metadata.error_handler == nullptr)
       std::exit(-1);
-    std::exit(this->error_handler(*this, err));
+    std::exit(this->metadata.error_handler(*this, err));
   }
 }
 

--- a/src/opzioni.cpp
+++ b/src/opzioni.cpp
@@ -243,22 +243,22 @@ constexpr bool has_cmd(ProgramView const program, std::string_view name) noexcep
 // | parsing helpers |
 // +-----------------+
 
-bool is_dash_dash(std::string_view const whole_arg) noexcept {
+constexpr bool is_dash_dash(std::string_view const whole_arg) noexcept {
   return whole_arg.length() == 2 && whole_arg[0] == '-' && whole_arg[1] == '-';
 }
 
-Cmd const *is_command(ProgramView const program, std::string_view const whole_arg) noexcept {
+constexpr Cmd const *is_command(ProgramView const program, std::string_view const whole_arg) noexcept {
   if (auto const cmd = find_cmd(program, whole_arg); cmd != program.cmds.end())
     return &*cmd;
   return nullptr;
 }
 
-bool looks_positional(std::string_view const whole_arg) noexcept {
+constexpr bool looks_positional(std::string_view const whole_arg) noexcept {
   auto const num_of_dashes = whole_arg.find_first_not_of('-');
   return num_of_dashes == 0 || (whole_arg.length() == 1 && num_of_dashes == std::string_view::npos);
 }
 
-std::string_view is_short_flags(ProgramView const program, std::string_view const whole_arg) noexcept {
+constexpr std::string_view is_short_flags(ProgramView const program, std::string_view const whole_arg) noexcept {
   auto const num_of_dashes = whole_arg.find_first_not_of('-');
   auto const flags = whole_arg.substr(1);
   auto const all_short_flags = std::all_of(
@@ -268,7 +268,7 @@ std::string_view is_short_flags(ProgramView const program, std::string_view cons
   return {};
 }
 
-std::string_view is_long_flag(ProgramView const program, std::string_view const whole_arg) noexcept {
+constexpr std::string_view is_long_flag(ProgramView const program, std::string_view const whole_arg) noexcept {
   auto const name = whole_arg.substr(2);
   auto const num_of_dashes = whole_arg.find_first_not_of('-');
   if (num_of_dashes == 2 && name.length() >= 2 && is_flag(program, name))
@@ -276,14 +276,16 @@ std::string_view is_long_flag(ProgramView const program, std::string_view const 
   return {};
 }
 
-std::optional<ParsedOption> is_option(ProgramView const program, std::string_view const whole_arg) noexcept {
+constexpr std::optional<ParsedOption> is_option(ProgramView const program, std::string_view const whole_arg) noexcept {
   auto const parsed_option = parse_option(whole_arg);
   if (has_opt(program, parsed_option.name))
     return parsed_option;
   return std::nullopt;
 }
 
-bool is_flag(ProgramView const program, std::string_view const name) noexcept { return has_flg(program, name); }
+constexpr bool is_flag(ProgramView const program, std::string_view const name) noexcept {
+  return has_flg(program, name);
+}
 
 // +---------------------+
 // | parsing assignments |
@@ -354,7 +356,7 @@ std::size_t Program::assign_option(ArgMap &map, std::span<char const *> args, Pa
   }
 }
 
-ParsedOption parse_option(std::string_view const whole_arg) noexcept {
+constexpr ParsedOption parse_option(std::string_view const whole_arg) noexcept {
   auto const num_of_dashes = whole_arg.find_first_not_of('-');
   auto const eq_idx = whole_arg.find('=', num_of_dashes);
   bool const has_equals = eq_idx != std::string_view::npos;

--- a/src/opzioni.cpp
+++ b/src/opzioni.cpp
@@ -291,7 +291,7 @@ constexpr bool is_flag(ProgramView const program, std::string_view const name) n
 // | parsing assignments |
 // +---------------------+
 
-std::size_t Program::assign_command(ArgMap &map, std::span<char const *> args, Cmd const &cmd) const {
+std::size_t assign_command(ArgMap &map, std::span<char const *> args, Cmd const &cmd) {
   auto const exec_path = fmt::format("{} {}", map.exec_path, cmd.program->metadata.name);
   args[0] = exec_path.data();
   map.cmd_name = cmd.program->metadata.name;

--- a/src/opzioni.cpp
+++ b/src/opzioni.cpp
@@ -175,9 +175,9 @@ ArgMap Program::parse(std::span<char const *> args) const {
         index += assign_positional(*this, map, args.subspan(index), current_positional_idx);
         ++current_positional_idx;
       } else if (auto const flags = is_short_flags(*this, arg); !flags.empty()) {
-        index += assign_many_flags(map, flags);
+        index += assign_many_flags(*this, map, flags);
       } else if (auto const flag = is_long_flag(*this, arg); !flag.empty()) {
-        index += assign_flag(map, flag);
+        index += assign_flag(*this, map, flag);
       } else if (auto const option = is_option(*this, arg); option.has_value()) {
         index += assign_option(map, args.subspan(index), *option);
       } else {
@@ -316,16 +316,16 @@ std::size_t assign_positional(ProgramView const program, ArgMap &map, std::span<
   return gather_amount;
 }
 
-std::size_t Program::assign_many_flags(ArgMap &map, std::string_view flags) const {
+std::size_t assign_many_flags(ProgramView const program, ArgMap &map, std::string_view flags) {
   for (auto const flag : flags) {
-    assign_flag(map, std::string_view(&flag, 1));
+    assign_flag(program, map, std::string_view(&flag, 1));
   }
   return 1;
 }
 
-std::size_t Program::assign_flag(ArgMap &map, std::string_view flag) const {
-  auto const &arg = *find_arg(*this, flag, ArgType::FLG);
-  arg.action_fn(*this, map, arg, std::nullopt);
+std::size_t assign_flag(ProgramView const program, ArgMap &map, std::string_view flag) {
+  auto const &arg = *find_arg(program, flag, ArgType::FLG);
+  arg.action_fn(program, map, arg, std::nullopt);
   return 1;
 }
 

--- a/src/opzioni.cpp
+++ b/src/opzioni.cpp
@@ -98,62 +98,6 @@ std::string ProgramView::format_for_help_index() const noexcept { return this->f
 
 std::string ProgramView::format_for_usage_summary() const noexcept { return std::string(this->metadata.name); }
 
-auto ProgramView::operator<=>(ProgramView const &other) const noexcept {
-  return this->metadata.name <=> other.metadata.name;
-}
-
-Program &Program::intro(std::string_view introduction) noexcept {
-  this->metadata.introduction = introduction;
-  return *this;
-}
-
-Program &Program::details(std::string_view description) noexcept {
-  this->metadata.description = description;
-  return *this;
-}
-
-Program &Program::version(std::string_view version) noexcept {
-  this->metadata.version = version;
-  return *this;
-}
-
-Program &Program::max_width(std::size_t msg_width) noexcept {
-  this->metadata.msg_width = msg_width;
-  return *this;
-}
-
-Program &Program::on_error(ErrorHandler error_handler) noexcept {
-  this->metadata.error_handler = error_handler;
-  return *this;
-}
-
-Program &Program::add(Arg arg) {
-  _args.push_back(arg);
-  metadata.positionals_amount += (arg.type == ArgType::POS);
-  return *this;
-}
-
-Program &Program::add(ProgramView cmd) {
-  if (has_cmd(*this, cmd.metadata.name))
-    throw ArgumentAlreadyExists(cmd.metadata.name);
-  _cmds.push_back(cmd);
-  return *this;
-}
-
-ArgMap Program::operator()(int argc, char const *argv[]) const noexcept {
-  return (*this)(std::span<char const *>{argv, static_cast<std::size_t>(argc)});
-}
-
-ArgMap Program::operator()(std::span<char const *> args) const noexcept {
-  try {
-    return parse(*this, args);
-  } catch (UserError const &err) {
-    if (this->metadata.error_handler == nullptr)
-      std::exit(-1);
-    std::exit(this->metadata.error_handler(*this, err));
-  }
-}
-
 ArgMap parse_args(ProgramView const program, std::span<char const *> args) {
   ArgMap map;
   if (args.size() > 0) {

--- a/test_package/main.cpp
+++ b/test_package/main.cpp
@@ -6,7 +6,7 @@
 int main(int argc, char const *argv[]) {
   using opzioni::Program, opzioni::Pos, opzioni::Help;
 
-  auto program = Program("test-package") + Pos("name").help("Your name") * Help();
+  constexpr auto program = Program("test-package") + Pos("name").help("Your name") * Help();
 
   auto const args = program(argc, argv);
   std::cout << "Number of arguments: " << args.size() << '\n';

--- a/test_package/meson.build
+++ b/test_package/meson.build
@@ -3,7 +3,7 @@ project(
     default_options: ['cpp_std=c++2a', 'buildtype=debug']
 )
 
-opzioni_dep = dependency('opzioni', version: '0.43.0')
+opzioni_dep = dependency('opzioni', version: '0.44.0')
 
 main = executable(
     'main', 'main.cpp',

--- a/tests/opzioni.program.cpp
+++ b/tests/opzioni.program.cpp
@@ -19,8 +19,8 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
       REQUIRE(program.metadata.introduction.empty());
       REQUIRE(program.metadata.description.empty());
       REQUIRE(program.metadata.msg_width == 100);
-      REQUIRE(program.error_handler == print_error);
       REQUIRE(program.metadata.positionals_amount == 0);
+      REQUIRE(program.metadata.error_handler == print_error);
       REQUIRE(program.args().size() == 0);
       REQUIRE(program.cmds().size() == 0);
     }
@@ -35,8 +35,8 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
         REQUIRE(program.metadata.title.empty());
         REQUIRE(program.metadata.description.empty());
         REQUIRE(program.metadata.msg_width == 100);
-        REQUIRE(program.error_handler == print_error);
         REQUIRE(program.metadata.positionals_amount == 0);
+        REQUIRE(program.metadata.error_handler == print_error);
         REQUIRE(program.args().size() == 0);
         REQUIRE(program.cmds().size() == 0);
       }
@@ -52,8 +52,8 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
         REQUIRE(program.metadata.title.empty());
         REQUIRE(program.metadata.introduction.empty());
         REQUIRE(program.metadata.msg_width == 100);
-        REQUIRE(program.error_handler == print_error);
         REQUIRE(program.metadata.positionals_amount == 0);
+        REQUIRE(program.metadata.error_handler == print_error);
         REQUIRE(program.args().size() == 0);
         REQUIRE(program.cmds().size() == 0);
       }
@@ -69,8 +69,8 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
         REQUIRE(program.metadata.introduction.empty());
         REQUIRE(program.metadata.description.empty());
         REQUIRE(program.metadata.msg_width == 100);
-        REQUIRE(program.error_handler == print_error);
         REQUIRE(program.metadata.positionals_amount == 0);
+        REQUIRE(program.metadata.error_handler == print_error);
         REQUIRE(program.args().size() == 0);
         REQUIRE(program.cmds().size() == 0);
       }
@@ -86,8 +86,8 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
         REQUIRE(program.metadata.name.empty());
         REQUIRE(program.metadata.title.empty());
         REQUIRE(program.metadata.msg_width == 100);
-        REQUIRE(program.error_handler == print_error);
         REQUIRE(program.metadata.positionals_amount == 0);
+        REQUIRE(program.metadata.error_handler == print_error);
         REQUIRE(program.args().size() == 0);
         REQUIRE(program.cmds().size() == 0);
       }
@@ -103,8 +103,8 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
         REQUIRE(program.metadata.title.empty());
         REQUIRE(program.metadata.introduction.empty());
         REQUIRE(program.metadata.description.empty());
-        REQUIRE(program.error_handler == print_error);
         REQUIRE(program.metadata.positionals_amount == 0);
+        REQUIRE(program.metadata.error_handler == print_error);
         REQUIRE(program.args().size() == 0);
         REQUIRE(program.cmds().size() == 0);
       }
@@ -114,7 +114,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
       program.on_error(nullptr);
 
       THEN("only the error_handler should be changed") {
-        REQUIRE(program.error_handler == nullptr);
+        REQUIRE(program.metadata.error_handler == nullptr);
         REQUIRE(program.metadata.name.empty());
         REQUIRE(program.metadata.version.empty());
         REQUIRE(program.metadata.title.empty());
@@ -135,7 +135,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
         REQUIRE(program.metadata.description == "details");
         REQUIRE(program.metadata.version == "1.0");
         REQUIRE(program.metadata.msg_width == 80);
-        REQUIRE(program.error_handler == nullptr);
+        REQUIRE(program.metadata.error_handler == nullptr);
         REQUIRE(program.metadata.name.empty());
         REQUIRE(program.metadata.title.empty());
         REQUIRE(program.metadata.positionals_amount == 0);
@@ -155,8 +155,8 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
       REQUIRE(program.metadata.introduction.empty());
       REQUIRE(program.metadata.description.empty());
       REQUIRE(program.metadata.msg_width == 100);
-      REQUIRE(program.error_handler == print_error);
       REQUIRE(program.metadata.positionals_amount == 0);
+      REQUIRE(program.metadata.error_handler == print_error);
       REQUIRE(program.args().size() == 0);
       REQUIRE(program.cmds().size() == 0);
     }
@@ -172,8 +172,8 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
       REQUIRE(program.metadata.introduction.empty());
       REQUIRE(program.metadata.description.empty());
       REQUIRE(program.metadata.msg_width == 100);
-      REQUIRE(program.error_handler == print_error);
       REQUIRE(program.metadata.positionals_amount == 0);
+      REQUIRE(program.metadata.error_handler == print_error);
       REQUIRE(program.args().size() == 0);
       REQUIRE(program.cmds().size() == 0);
     }

--- a/tests/opzioni.program.cpp
+++ b/tests/opzioni.program.cpp
@@ -10,7 +10,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
   using namespace opzioni;
 
   GIVEN("a default-initialized Program") {
-    Program program;
+    constexpr Program program;
 
     THEN("all member variables should have their defaults") {
       REQUIRE(program.metadata.name.empty());
@@ -21,8 +21,8 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
       REQUIRE(program.metadata.msg_width == 100);
       REQUIRE(program.metadata.positionals_amount == 0);
       REQUIRE(program.metadata.error_handler == print_error);
-      REQUIRE(program.args().size() == 0);
-      REQUIRE(program.cmds().size() == 0);
+      REQUIRE(program.args.size() == 0);
+      REQUIRE(program.cmds.size() == 0);
     }
 
     WHEN("intro is called") {
@@ -37,8 +37,8 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
         REQUIRE(program.metadata.msg_width == 100);
         REQUIRE(program.metadata.positionals_amount == 0);
         REQUIRE(program.metadata.error_handler == print_error);
-        REQUIRE(program.args().size() == 0);
-        REQUIRE(program.cmds().size() == 0);
+        REQUIRE(program.args.size() == 0);
+        REQUIRE(program.cmds.size() == 0);
       }
     }
 
@@ -54,8 +54,8 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
         REQUIRE(program.metadata.msg_width == 100);
         REQUIRE(program.metadata.positionals_amount == 0);
         REQUIRE(program.metadata.error_handler == print_error);
-        REQUIRE(program.args().size() == 0);
-        REQUIRE(program.cmds().size() == 0);
+        REQUIRE(program.args.size() == 0);
+        REQUIRE(program.cmds.size() == 0);
       }
     }
 
@@ -71,8 +71,8 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
         REQUIRE(program.metadata.msg_width == 100);
         REQUIRE(program.metadata.positionals_amount == 0);
         REQUIRE(program.metadata.error_handler == print_error);
-        REQUIRE(program.args().size() == 0);
-        REQUIRE(program.cmds().size() == 0);
+        REQUIRE(program.args.size() == 0);
+        REQUIRE(program.cmds.size() == 0);
       }
     }
 
@@ -88,8 +88,8 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
         REQUIRE(program.metadata.msg_width == 100);
         REQUIRE(program.metadata.positionals_amount == 0);
         REQUIRE(program.metadata.error_handler == print_error);
-        REQUIRE(program.args().size() == 0);
-        REQUIRE(program.cmds().size() == 0);
+        REQUIRE(program.args.size() == 0);
+        REQUIRE(program.cmds.size() == 0);
       }
     }
 
@@ -105,8 +105,8 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
         REQUIRE(program.metadata.description.empty());
         REQUIRE(program.metadata.positionals_amount == 0);
         REQUIRE(program.metadata.error_handler == print_error);
-        REQUIRE(program.args().size() == 0);
-        REQUIRE(program.cmds().size() == 0);
+        REQUIRE(program.args.size() == 0);
+        REQUIRE(program.cmds.size() == 0);
       }
     }
 
@@ -122,8 +122,8 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
         REQUIRE(program.metadata.description.empty());
         REQUIRE(program.metadata.msg_width == 100);
         REQUIRE(program.metadata.positionals_amount == 0);
-        REQUIRE(program.args().size() == 0);
-        REQUIRE(program.cmds().size() == 0);
+        REQUIRE(program.args.size() == 0);
+        REQUIRE(program.cmds.size() == 0);
       }
     }
 
@@ -139,14 +139,14 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
         REQUIRE(program.metadata.name.empty());
         REQUIRE(program.metadata.title.empty());
         REQUIRE(program.metadata.positionals_amount == 0);
-        REQUIRE(program.args().size() == 0);
-        REQUIRE(program.cmds().size() == 0);
+        REQUIRE(program.args.size() == 0);
+        REQUIRE(program.cmds.size() == 0);
       }
     }
   }
 
   GIVEN("a Program initialized with a name") {
-    Program const program("program");
+    constexpr Program program("program");
 
     THEN("only the name should not have its default value") {
       REQUIRE(program.metadata.name == "program");
@@ -157,13 +157,13 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
       REQUIRE(program.metadata.msg_width == 100);
       REQUIRE(program.metadata.positionals_amount == 0);
       REQUIRE(program.metadata.error_handler == print_error);
-      REQUIRE(program.args().size() == 0);
-      REQUIRE(program.cmds().size() == 0);
+      REQUIRE(program.args.size() == 0);
+      REQUIRE(program.cmds.size() == 0);
     }
   }
 
   GIVEN("a Program initialized with a name and title") {
-    Program const program("program", "title");
+    constexpr Program program("program", "title");
 
     THEN("only name and title should not have their default values") {
       REQUIRE(program.metadata.name == "program");
@@ -174,8 +174,8 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
       REQUIRE(program.metadata.msg_width == 100);
       REQUIRE(program.metadata.positionals_amount == 0);
       REQUIRE(program.metadata.error_handler == print_error);
-      REQUIRE(program.args().size() == 0);
-      REQUIRE(program.cmds().size() == 0);
+      REQUIRE(program.args.size() == 0);
+      REQUIRE(program.cmds.size() == 0);
     }
   }
 }
@@ -185,214 +185,140 @@ SCENARIO("adding arguments", "[Program][args]") {
   using namespace std::string_view_literals;
 
   GIVEN("an empty Program") {
-    Program program;
-
-    THEN("it should initially have no arguments") {
-      REQUIRE(program.args().size() == 0);
-      REQUIRE(program.cmds().size() == 0);
-      REQUIRE(program.metadata.positionals_amount == 0);
-    }
 
     WHEN("a positional is added") {
-      program + std::array{Pos("pos")};
+      constexpr auto program = Program() + std::array{Pos("pos")};
 
-      THEN("the size of args should match the number of arguments added") { REQUIRE(program.args().size() == 1); }
-      THEN("cmds should not be changed") { REQUIRE(program.cmds().size() == 0); }
+      THEN("the size of args should match the number of arguments added") { REQUIRE(program.args.size() == 1); }
+      THEN("cmds should not be changed") { REQUIRE(program.cmds.size() == 0); }
       THEN("positionals_amount should match the number of positionals added") {
         REQUIRE(program.metadata.positionals_amount == 1);
       }
-      THEN("the positional should be added as first argument") { REQUIRE(program.args()[0].name == "pos"); }
+      THEN("the positional should be added as first argument") { REQUIRE(program.args[0].name == "pos"); }
     }
 
     WHEN("two positionals are added") {
-      program + Pos("pos1") * Pos("pos2");
+      constexpr auto program = Program() + Pos("pos1") * Pos("pos2");
 
-      THEN("the size of args should match the number of arguments added") { REQUIRE(program.args().size() == 2); }
-      THEN("cmds should not be changed") { REQUIRE(program.cmds().size() == 0); }
+      THEN("the size of args should match the number of arguments added") { REQUIRE(program.args.size() == 2); }
+      THEN("cmds should not be changed") { REQUIRE(program.cmds.size() == 0); }
       THEN("positionals_amount should match the number of positionals added") {
         REQUIRE(program.metadata.positionals_amount == 2);
       }
       THEN("positionals should be added as first arguments, but preserving the order of insertion") {
-        REQUIRE(program.args()[0].name == "pos1");
-        REQUIRE(program.args()[1].name == "pos2");
+        REQUIRE(program.args[0].name == "pos1");
+        REQUIRE(program.args[1].name == "pos2");
       }
     }
 
     WHEN("multiple positionals are added") {
-      program + Pos("pos5") * Pos("pos2") * Pos("pos4") * Pos("pos1") * Pos("pos3");
+      constexpr auto program = Program() + Pos("pos5") * Pos("pos2") * Pos("pos4") * Pos("pos1") * Pos("pos3");
 
-      THEN("the size of args should match the number of arguments added") { REQUIRE(program.args().size() == 5); }
-      THEN("cmds should not be changed") { REQUIRE(program.cmds().size() == 0); }
+      THEN("the size of args should match the number of arguments added") { REQUIRE(program.args.size() == 5); }
+      THEN("cmds should not be changed") { REQUIRE(program.cmds.size() == 0); }
       THEN("positionals_amount should match the number of positionals added") {
         REQUIRE(program.metadata.positionals_amount == 5);
       }
       THEN("positionals should be added as first arguments, but preserving the order of insertion") {
-        REQUIRE(program.args()[0].name == "pos5");
-        REQUIRE(program.args()[1].name == "pos2");
-        REQUIRE(program.args()[2].name == "pos4");
-        REQUIRE(program.args()[3].name == "pos1");
-        REQUIRE(program.args()[4].name == "pos3");
+        REQUIRE(program.args[0].name == "pos5");
+        REQUIRE(program.args[1].name == "pos2");
+        REQUIRE(program.args[2].name == "pos4");
+        REQUIRE(program.args[3].name == "pos1");
+        REQUIRE(program.args[4].name == "pos3");
       }
     }
 
     WHEN("other arguments are added before positionals") {
-      program + Flg("flg1") * Opt("opt2") * Pos("pos3") * Pos("pos1") * Pos("pos2") * Opt("opt1") * Flg("flg2");
+      constexpr auto program =
+          Program() + Flg("flg1") * Opt("opt2") * Pos("pos3") * Pos("pos1") * Pos("pos2") * Opt("opt1") * Flg("flg2");
 
-      THEN("the size of args should match the number of arguments added") { REQUIRE(program.args().size() == 7); }
-      THEN("cmds should not be changed") { REQUIRE(program.cmds().size() == 0); }
+      THEN("the size of args should match the number of arguments added") { REQUIRE(program.args.size() == 7); }
+      THEN("cmds should not be changed") { REQUIRE(program.cmds.size() == 0); }
       THEN("positionals_amount should match the number of positionals added") {
         REQUIRE(program.metadata.positionals_amount == 3);
       }
       THEN("positionals should be added as first arguments, but preserving the order of insertion") {
-        REQUIRE(program.args()[0].name == "pos3");
-        REQUIRE(program.args()[1].name == "pos1");
-        REQUIRE(program.args()[2].name == "pos2");
+        REQUIRE(program.args[0].name == "pos3");
+        REQUIRE(program.args[1].name == "pos1");
+        REQUIRE(program.args[2].name == "pos2");
       }
       THEN("the rest of the arguments should be sorted lexicographically by name") {
         // also using is_sorted to check `operator<`
-        REQUIRE(std::is_sorted(std::next(program.args().begin(), program.metadata.positionals_amount),
-                               program.args().end()));
-        REQUIRE(program.args()[3].name == "flg1");
-        REQUIRE(program.args()[4].name == "flg2");
-        REQUIRE(program.args()[5].name == "opt1");
-        REQUIRE(program.args()[6].name == "opt2");
-      }
-    }
-  }
-
-  WHEN("adding arguments directly to a new Program") {
-    auto const program =
-        Program() + Flg("flg1") * Opt("opt2") * Pos("pos3") * Pos("pos1") * Pos("pos2") * Opt("opt1") * Flg("flg2");
-
-    THEN("the size of args should match the number of arguments added") { REQUIRE(program.args().size() == 7); }
-    THEN("cmds should be empty") { REQUIRE(program.cmds().size() == 0); }
-    THEN("positionals_amount should match the number of positionals added") {
-      REQUIRE(program.metadata.positionals_amount == 3);
-    }
-    THEN("positionals should be added as first arguments, but preserving the order of insertion") {
-      REQUIRE(program.args()[0].name == "pos3");
-      REQUIRE(program.args()[1].name == "pos1");
-      REQUIRE(program.args()[2].name == "pos2");
-    }
-    THEN("the rest of the arguments should be sorted lexicographically by name") {
-      // also using is_sorted to check `operator<`
-      REQUIRE(
-          std::is_sorted(std::next(program.args().begin(), program.metadata.positionals_amount), program.args().end()));
-      REQUIRE(program.args()[3].name == "flg1");
-      REQUIRE(program.args()[4].name == "flg2");
-      REQUIRE(program.args()[5].name == "opt1");
-      REQUIRE(program.args()[6].name == "opt2");
-    }
-  }
-}
-
-SCENARIO("adding commands", "[Program][cmds]") {
-  using namespace opzioni;
-  using namespace std::string_view_literals;
-
-  GIVEN("program and cmd") {
-    auto const cmd_name = "cmd"sv;
-    Program const cmd(cmd_name);
-    Program program;
-
-    THEN("they should initially have no arguments") {
-      REQUIRE(program.args().size() == 0);
-      REQUIRE(program.cmds().size() == 0);
-      REQUIRE(program.metadata.positionals_amount == 0);
-
-      REQUIRE(cmd.args().size() == 0);
-      REQUIRE(cmd.cmds().size() == 0);
-      REQUIRE(cmd.metadata.positionals_amount == 0);
-    }
-
-    WHEN("cmd is added as command of program") {
-      program + cmd;
-
-      THEN("cmd should be added as only command of program") {
-        REQUIRE(program.cmds().size() == 1);
-        REQUIRE(program.cmds()[0].metadata == cmd.metadata);
-      }
-      THEN("program's args should not be changed") {
-        REQUIRE(program.args().size() == 0);
-        REQUIRE(program.metadata.positionals_amount == 0);
-      }
-
-      AND_WHEN("another command with the same name is added to program") {
-        Program other_cmd("cmd");
-
-        THEN("we should thow an error because of duplicate name") {
-          REQUIRE_THROWS_AS(program + cmd + other_cmd, ArgumentAlreadyExists);
-        }
-      }
-
-      AND_GIVEN("another command, cmd2") {
-        auto const cmd2_name = "cmd2";
-        Program const cmd2(cmd2_name);
-
-        THEN("cmd2 should initially have no arguments") {
-          REQUIRE(cmd2.args().size() == 0);
-          REQUIRE(cmd2.cmds().size() == 0);
-          REQUIRE(cmd2.metadata.positionals_amount == 0);
-        }
-
-        WHEN("cmd2 is added as command of program") {
-          program + cmd2;
-
-          THEN("cmd2 should be added as second command of program") {
-            REQUIRE(program.cmds().size() == 2);
-            REQUIRE(program.cmds()[0].metadata == cmd.metadata);
-            REQUIRE(program.cmds()[1].metadata == cmd2.metadata);
-          }
-          THEN("program's args should not be changed") {
-            REQUIRE(program.args().size() == 0);
-            REQUIRE(program.metadata.positionals_amount == 0);
-          }
-        }
-      }
-    }
-
-    AND_WHEN("cmd is added as command of program twice") {
-      THEN("we should thow an error because of duplicate name") {
-        REQUIRE_THROWS_AS(program + cmd + cmd, ArgumentAlreadyExists);
-      }
-    }
-  }
-
-  GIVEN("program, cmd1, and cmd2") {
-    auto const cmd1_name = "cmd1"sv, cmd2_name = "cmd2"sv;
-    Program const cmd1(cmd1_name);
-    Program const cmd2(cmd2_name);
-    Program program;
-
-    THEN("they should initially have no arguments") {
-      REQUIRE(program.args().size() == 0);
-      REQUIRE(program.cmds().size() == 0);
-      REQUIRE(program.metadata.positionals_amount == 0);
-
-      REQUIRE(cmd1.args().size() == 0);
-      REQUIRE(cmd1.cmds().size() == 0);
-      REQUIRE(cmd1.metadata.positionals_amount == 0);
-
-      REQUIRE(cmd2.args().size() == 0);
-      REQUIRE(cmd2.cmds().size() == 0);
-      REQUIRE(cmd2.metadata.positionals_amount == 0);
-    }
-
-    WHEN("both are added as commands of program, but cmd2 first") {
-      program + cmd2 + cmd1;
-
-      THEN("cmd2 should be added as first command of program and cmd1 as second") {
-        REQUIRE(program.cmds().size() == 2);
-        REQUIRE(program.cmds()[0].metadata == cmd2.metadata);
-        REQUIRE(program.cmds()[1].metadata == cmd1.metadata);
-      }
-      THEN("program's args should not be changed") {
-        REQUIRE(program.args().size() == 0);
-        REQUIRE(program.metadata.positionals_amount == 0);
+        REQUIRE(
+            std::is_sorted(std::next(program.args.begin(), program.metadata.positionals_amount), program.args.end()));
+        REQUIRE(program.args[3].name == "flg1");
+        REQUIRE(program.args[4].name == "flg2");
+        REQUIRE(program.args[5].name == "opt1");
+        REQUIRE(program.args[6].name == "opt2");
       }
     }
   }
 }
+
+// SCENARIO("adding commands", "[Program][cmds]") {
+//   using namespace opzioni;
+//   using namespace std::string_view_literals;
+
+//   GIVEN("program and cmd") {
+//     constexpr auto cmd_name = "cmd"sv;
+//     constexpr Program cmd(cmd_name);
+
+//     THEN("cmd should have no arguments") {
+//       REQUIRE(cmd.args.size() == 0);
+//       REQUIRE(cmd.cmds.size() == 0);
+//       REQUIRE(cmd.metadata.positionals_amount == 0);
+//     }
+
+//     WHEN("cmd is added as command of program") {
+//       constexpr auto program = Program() + std::array{Cmd(cmd)};
+
+//       THEN("cmd should be added as only command of program") {
+//         REQUIRE(program.cmds.size() == 1);
+//         REQUIRE(program.cmds[0].metadata == cmd.metadata);
+//       }
+//       THEN("program's args should not be changed") {
+//         REQUIRE(program.args.size() == 0);
+//         REQUIRE(program.metadata.positionals_amount == 0);
+//       }
+//     }
+
+//     AND_WHEN("cmd is added as command of program twice") {
+//       THEN("we should thow an error because of duplicate name") {
+//         REQUIRE_THROWS_AS(Program() + Cmd(cmd) * Cmd(cmd), ArgumentAlreadyExists);
+//       }
+//     }
+//   }
+
+//   GIVEN("program, cmd1, and cmd2") {
+//     constexpr auto cmd1_name = "cmd1"sv, cmd2_name = "cmd2"sv;
+//     constexpr Program cmd1(cmd1_name);
+//     constexpr Program cmd2(cmd2_name);
+
+//     THEN("thee cmds should have no arguments") {
+//       REQUIRE(cmd1.args.size() == 0);
+//       REQUIRE(cmd1.cmds.size() == 0);
+//       REQUIRE(cmd1.metadata.positionals_amount == 0);
+
+//       REQUIRE(cmd2.args.size() == 0);
+//       REQUIRE(cmd2.cmds.size() == 0);
+//       REQUIRE(cmd2.metadata.positionals_amount == 0);
+//     }
+
+//     WHEN("both cmds are added as commands of program, but cmd2 first") {
+//       constexpr auto program = Program() + Cmd(cmd2) * Cmd(cmd1);
+
+//       THEN("cmd2 should be added as first command of program and cmd1 as second") {
+//         REQUIRE(program.cmds.size() == 2);
+//         REQUIRE(program.cmds[0].metadata == cmd2.metadata);
+//         REQUIRE(program.cmds[1].metadata == cmd1.metadata);
+//       }
+//       THEN("program's args should not be changed") {
+//         REQUIRE(program.args.size() == 0);
+//         REQUIRE(program.metadata.positionals_amount == 0);
+//       }
+//     }
+//   }
+// }
 
 SCENARIO("parsing", "[Program][parsing]") {
   using namespace opzioni;
@@ -512,61 +438,61 @@ SCENARIO("parsing", "[Program][parsing]") {
     }
   }
 
-  GIVEN("a program with all kinds of arguments and a command") {
-    constexpr auto cmd_args = Flg("f") * Pos("pos1") * Pos("cmd-pos") * Opt("long", "l");
-    auto const cmd = Program("cmd").on_error(rethrow) + cmd_args;
+//   GIVEN("a program with all kinds of arguments and a command") {
+//     constexpr auto cmd_args = Flg("f") * Pos("pos1") * Pos("cmd-pos") * Opt("long", "l");
+//     constexpr auto cmd = Program("cmd").on_error(rethrow) + cmd_args;
 
-    constexpr auto args = Pos("pos2") * Opt("long") * Flg("flg") * Opt("longer-opt", "l") * Pos("pos1") *
-                          Flg("glf", "g") * Flg("f") * Opt("o");
-    auto const program = Program().on_error(rethrow) + args + cmd;
+//     constexpr auto args = Pos("pos2") * Opt("long") * Flg("flg") * Opt("longer-opt", "l") * Pos("pos1") *
+//                           Flg("glf", "g") * Flg("f") * Opt("o");
+//     constexpr auto program = Program().on_error(rethrow) + args + cmd;
 
-    WHEN("an empty argv is parsed") {
-      std::array<char const *, 0> argv;
+//     WHEN("an empty argv is parsed") {
+//       std::array<char const *, 0> argv;
 
-      THEN("we should throw an error because of missing required arguments") {
-        REQUIRE_THROWS_AS(program(std::span(argv)), UserError);
-      }
-    }
+//       THEN("we should throw an error because of missing required arguments") {
+//         REQUIRE_THROWS_AS(program(std::span(argv)), UserError);
+//       }
+//     }
 
-    AND_WHEN("an argv with only 1 element is parsed") {
-      auto argv = std::array{"./program"};
+//     AND_WHEN("an argv with only 1 element is parsed") {
+//       auto argv = std::array{"./program"};
 
-      THEN("we should throw an error because of missing required arguments") {
-        REQUIRE_THROWS_AS(program(std::span(argv)), UserError);
-      }
-    }
+//       THEN("we should throw an error because of missing required arguments") {
+//         REQUIRE_THROWS_AS(program(std::span(argv)), UserError);
+//       }
+//     }
 
-    AND_WHEN("all arguments are parsed, all long names, positionals given last") {
-      auto argv =
-          std::array{"./program", "--long", "long-val", "--flg", "--longer-opt", "longer-opt-val", "--glf", "-f", "-o",
-                     "o-val",     "a",      "b",        "cmd",   "--long",       "long-val",       "-f",    "aa", "bb"};
+//     AND_WHEN("all arguments are parsed, all long names, positionals given last") {
+//       auto argv =
+//           std::array{"./program", "--long", "long-val", "--flg", "--longer-opt", "longer-opt-val", "--glf", "-f", "-o",
+//                      "o-val",     "a",      "b",        "cmd",   "--long",       "long-val",       "-f",    "aa", "bb"};
 
-      auto const map = program(std::span(argv));
+//       auto const map = program(std::span(argv));
 
-      THEN("exec_path should be set") { REQUIRE(map.exec_path == std::string_view(argv[0])); }
+//       THEN("exec_path should be set") { REQUIRE(map.exec_path == std::string_view(argv[0])); }
 
-      AND_THEN("args should have all the arguments of the main program") {
-        REQUIRE(map.args.size() == args.size());
-        REQUIRE(map.as<std::string_view>("long") == std::string_view(argv[2]));
-        REQUIRE(map.as<bool>("flg") == true);
-        REQUIRE(map.as<std::string_view>("longer-opt") == std::string_view(argv[5]));
-        REQUIRE(map.as<bool>("glf") == true);
-        REQUIRE(map.as<bool>("f") == true);
-        REQUIRE(map.as<std::string_view>("o") == std::string_view(argv[9]));
-        REQUIRE(map.as<std::string_view>("pos2") == std::string_view(argv[10]));
-        REQUIRE(map.as<std::string_view>("pos1") == std::string_view(argv[11]));
-      }
+//       AND_THEN("args should have all the arguments of the main program") {
+//         REQUIRE(map.args.size() == args.size());
+//         REQUIRE(map.as<std::string_view>("long") == std::string_view(argv[2]));
+//         REQUIRE(map.as<bool>("flg") == true);
+//         REQUIRE(map.as<std::string_view>("longer-opt") == std::string_view(argv[5]));
+//         REQUIRE(map.as<bool>("glf") == true);
+//         REQUIRE(map.as<bool>("f") == true);
+//         REQUIRE(map.as<std::string_view>("o") == std::string_view(argv[9]));
+//         REQUIRE(map.as<std::string_view>("pos2") == std::string_view(argv[10]));
+//         REQUIRE(map.as<std::string_view>("pos1") == std::string_view(argv[11]));
+//       }
 
-      AND_THEN("cmd_name should be set") { REQUIRE(map.cmd_name == cmd.metadata.name); }
-      AND_THEN("cmd_args should have all the arguments of the command") {
-        REQUIRE(map.cmd_args != nullptr);
+//       AND_THEN("cmd_name should be set") { REQUIRE(map.cmd_name == cmd.metadata.name); }
+//       AND_THEN("cmd_args should have all the arguments of the command") {
+//         REQUIRE(map.cmd_args != nullptr);
 
-        auto const &cmd_args = *map.cmd_args;
-        REQUIRE(cmd_args.as<std::string_view>("long") == std::string_view(argv[14]));
-        REQUIRE(cmd_args.as<bool>("f") == true);
-        REQUIRE(cmd_args.as<std::string_view>("pos1") == std::string_view(argv[16]));
-        REQUIRE(cmd_args.as<std::string_view>("cmd-pos") == std::string_view(argv[17]));
-      }
-    }
-  }
+//         auto const &cmd_args = *map.cmd_args;
+//         REQUIRE(cmd_args.as<std::string_view>("long") == std::string_view(argv[14]));
+//         REQUIRE(cmd_args.as<bool>("f") == true);
+//         REQUIRE(cmd_args.as<std::string_view>("pos1") == std::string_view(argv[16]));
+//         REQUIRE(cmd_args.as<std::string_view>("cmd-pos") == std::string_view(argv[17]));
+//       }
+//     }
+//   }
 }

--- a/tests/opzioni.program.cpp
+++ b/tests/opzioni.program.cpp
@@ -13,14 +13,14 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
     Program program;
 
     THEN("all member variables should have their defaults") {
-      REQUIRE(program.name.empty());
-      REQUIRE(program.version.empty());
-      REQUIRE(program.title.empty());
-      REQUIRE(program.introduction.empty());
-      REQUIRE(program.description.empty());
-      REQUIRE(program.msg_width == 100);
+      REQUIRE(program.metadata.name.empty());
+      REQUIRE(program.metadata.version.empty());
+      REQUIRE(program.metadata.title.empty());
+      REQUIRE(program.metadata.introduction.empty());
+      REQUIRE(program.metadata.description.empty());
+      REQUIRE(program.metadata.msg_width == 100);
       REQUIRE(program.error_handler == print_error);
-      REQUIRE(program.positionals_amount == 0);
+      REQUIRE(program.metadata.positionals_amount == 0);
       REQUIRE(program.args().size() == 0);
       REQUIRE(program.cmds().size() == 0);
     }
@@ -29,14 +29,14 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
       program.intro("intro");
 
       THEN("only the introduction should be changed") {
-        REQUIRE(program.introduction == "intro");
-        REQUIRE(program.name.empty());
-        REQUIRE(program.version.empty());
-        REQUIRE(program.title.empty());
-        REQUIRE(program.description.empty());
-        REQUIRE(program.msg_width == 100);
+        REQUIRE(program.metadata.introduction == "intro");
+        REQUIRE(program.metadata.name.empty());
+        REQUIRE(program.metadata.version.empty());
+        REQUIRE(program.metadata.title.empty());
+        REQUIRE(program.metadata.description.empty());
+        REQUIRE(program.metadata.msg_width == 100);
         REQUIRE(program.error_handler == print_error);
-        REQUIRE(program.positionals_amount == 0);
+        REQUIRE(program.metadata.positionals_amount == 0);
         REQUIRE(program.args().size() == 0);
         REQUIRE(program.cmds().size() == 0);
       }
@@ -46,14 +46,14 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
       program.details("details");
 
       THEN("only the description should be changed") {
-        REQUIRE(program.description == "details");
-        REQUIRE(program.name.empty());
-        REQUIRE(program.version.empty());
-        REQUIRE(program.title.empty());
-        REQUIRE(program.introduction.empty());
-        REQUIRE(program.msg_width == 100);
+        REQUIRE(program.metadata.description == "details");
+        REQUIRE(program.metadata.name.empty());
+        REQUIRE(program.metadata.version.empty());
+        REQUIRE(program.metadata.title.empty());
+        REQUIRE(program.metadata.introduction.empty());
+        REQUIRE(program.metadata.msg_width == 100);
         REQUIRE(program.error_handler == print_error);
-        REQUIRE(program.positionals_amount == 0);
+        REQUIRE(program.metadata.positionals_amount == 0);
         REQUIRE(program.args().size() == 0);
         REQUIRE(program.cmds().size() == 0);
       }
@@ -63,14 +63,14 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
       program.v("1.0");
 
       THEN("only the version should be changed") {
-        REQUIRE(program.version == "1.0");
-        REQUIRE(program.name.empty());
-        REQUIRE(program.title.empty());
-        REQUIRE(program.introduction.empty());
-        REQUIRE(program.description.empty());
-        REQUIRE(program.msg_width == 100);
+        REQUIRE(program.metadata.version == "1.0");
+        REQUIRE(program.metadata.name.empty());
+        REQUIRE(program.metadata.title.empty());
+        REQUIRE(program.metadata.introduction.empty());
+        REQUIRE(program.metadata.description.empty());
+        REQUIRE(program.metadata.msg_width == 100);
         REQUIRE(program.error_handler == print_error);
-        REQUIRE(program.positionals_amount == 0);
+        REQUIRE(program.metadata.positionals_amount == 0);
         REQUIRE(program.args().size() == 0);
         REQUIRE(program.cmds().size() == 0);
       }
@@ -80,14 +80,14 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
       program.intro("intro").details("details").v("1.0");
 
       THEN("all three should be changed") {
-        REQUIRE(program.introduction == "intro");
-        REQUIRE(program.description == "details");
-        REQUIRE(program.version == "1.0");
-        REQUIRE(program.name.empty());
-        REQUIRE(program.title.empty());
-        REQUIRE(program.msg_width == 100);
+        REQUIRE(program.metadata.introduction == "intro");
+        REQUIRE(program.metadata.description == "details");
+        REQUIRE(program.metadata.version == "1.0");
+        REQUIRE(program.metadata.name.empty());
+        REQUIRE(program.metadata.title.empty());
+        REQUIRE(program.metadata.msg_width == 100);
         REQUIRE(program.error_handler == print_error);
-        REQUIRE(program.positionals_amount == 0);
+        REQUIRE(program.metadata.positionals_amount == 0);
         REQUIRE(program.args().size() == 0);
         REQUIRE(program.cmds().size() == 0);
       }
@@ -97,14 +97,14 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
       program.max_width(80);
 
       THEN("only the msg_width should be changed") {
-        REQUIRE(program.msg_width == 80);
-        REQUIRE(program.name.empty());
-        REQUIRE(program.version.empty());
-        REQUIRE(program.title.empty());
-        REQUIRE(program.introduction.empty());
-        REQUIRE(program.description.empty());
+        REQUIRE(program.metadata.msg_width == 80);
+        REQUIRE(program.metadata.name.empty());
+        REQUIRE(program.metadata.version.empty());
+        REQUIRE(program.metadata.title.empty());
+        REQUIRE(program.metadata.introduction.empty());
+        REQUIRE(program.metadata.description.empty());
         REQUIRE(program.error_handler == print_error);
-        REQUIRE(program.positionals_amount == 0);
+        REQUIRE(program.metadata.positionals_amount == 0);
         REQUIRE(program.args().size() == 0);
         REQUIRE(program.cmds().size() == 0);
       }
@@ -115,13 +115,13 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
 
       THEN("only the error_handler should be changed") {
         REQUIRE(program.error_handler == nullptr);
-        REQUIRE(program.name.empty());
-        REQUIRE(program.version.empty());
-        REQUIRE(program.title.empty());
-        REQUIRE(program.introduction.empty());
-        REQUIRE(program.description.empty());
-        REQUIRE(program.msg_width == 100);
-        REQUIRE(program.positionals_amount == 0);
+        REQUIRE(program.metadata.name.empty());
+        REQUIRE(program.metadata.version.empty());
+        REQUIRE(program.metadata.title.empty());
+        REQUIRE(program.metadata.introduction.empty());
+        REQUIRE(program.metadata.description.empty());
+        REQUIRE(program.metadata.msg_width == 100);
+        REQUIRE(program.metadata.positionals_amount == 0);
         REQUIRE(program.args().size() == 0);
         REQUIRE(program.cmds().size() == 0);
       }
@@ -131,14 +131,14 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
       program.intro("intro").details("details").v("1.0").max_width(80).on_error(nullptr);
 
       THEN("all five should be changed") {
-        REQUIRE(program.introduction == "intro");
-        REQUIRE(program.description == "details");
-        REQUIRE(program.version == "1.0");
-        REQUIRE(program.msg_width == 80);
+        REQUIRE(program.metadata.introduction == "intro");
+        REQUIRE(program.metadata.description == "details");
+        REQUIRE(program.metadata.version == "1.0");
+        REQUIRE(program.metadata.msg_width == 80);
         REQUIRE(program.error_handler == nullptr);
-        REQUIRE(program.name.empty());
-        REQUIRE(program.title.empty());
-        REQUIRE(program.positionals_amount == 0);
+        REQUIRE(program.metadata.name.empty());
+        REQUIRE(program.metadata.title.empty());
+        REQUIRE(program.metadata.positionals_amount == 0);
         REQUIRE(program.args().size() == 0);
         REQUIRE(program.cmds().size() == 0);
       }
@@ -149,14 +149,14 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
     Program const program("program");
 
     THEN("only the name should not have its default value") {
-      REQUIRE(program.name == "program");
-      REQUIRE(program.version.empty());
-      REQUIRE(program.title.empty());
-      REQUIRE(program.introduction.empty());
-      REQUIRE(program.description.empty());
-      REQUIRE(program.msg_width == 100);
+      REQUIRE(program.metadata.name == "program");
+      REQUIRE(program.metadata.version.empty());
+      REQUIRE(program.metadata.title.empty());
+      REQUIRE(program.metadata.introduction.empty());
+      REQUIRE(program.metadata.description.empty());
+      REQUIRE(program.metadata.msg_width == 100);
       REQUIRE(program.error_handler == print_error);
-      REQUIRE(program.positionals_amount == 0);
+      REQUIRE(program.metadata.positionals_amount == 0);
       REQUIRE(program.args().size() == 0);
       REQUIRE(program.cmds().size() == 0);
     }
@@ -166,14 +166,14 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
     Program const program("program", "title");
 
     THEN("only name and title should not have their default values") {
-      REQUIRE(program.name == "program");
-      REQUIRE(program.title == "title");
-      REQUIRE(program.version.empty());
-      REQUIRE(program.introduction.empty());
-      REQUIRE(program.description.empty());
-      REQUIRE(program.msg_width == 100);
+      REQUIRE(program.metadata.name == "program");
+      REQUIRE(program.metadata.title == "title");
+      REQUIRE(program.metadata.version.empty());
+      REQUIRE(program.metadata.introduction.empty());
+      REQUIRE(program.metadata.description.empty());
+      REQUIRE(program.metadata.msg_width == 100);
       REQUIRE(program.error_handler == print_error);
-      REQUIRE(program.positionals_amount == 0);
+      REQUIRE(program.metadata.positionals_amount == 0);
       REQUIRE(program.args().size() == 0);
       REQUIRE(program.cmds().size() == 0);
     }
@@ -190,7 +190,7 @@ SCENARIO("adding arguments", "[Program][args]") {
     THEN("it should initially have no arguments") {
       REQUIRE(program.args().size() == 0);
       REQUIRE(program.cmds().size() == 0);
-      REQUIRE(program.positionals_amount == 0);
+      REQUIRE(program.metadata.positionals_amount == 0);
     }
 
     WHEN("a positional is added") {
@@ -199,7 +199,7 @@ SCENARIO("adding arguments", "[Program][args]") {
       THEN("the size of args should match the number of arguments added") { REQUIRE(program.args().size() == 1); }
       THEN("cmds should not be changed") { REQUIRE(program.cmds().size() == 0); }
       THEN("positionals_amount should match the number of positionals added") {
-        REQUIRE(program.positionals_amount == 1);
+        REQUIRE(program.metadata.positionals_amount == 1);
       }
       THEN("the positional should be added as first argument") { REQUIRE(program.args()[0].name == "pos"); }
     }
@@ -210,7 +210,7 @@ SCENARIO("adding arguments", "[Program][args]") {
       THEN("the size of args should match the number of arguments added") { REQUIRE(program.args().size() == 2); }
       THEN("cmds should not be changed") { REQUIRE(program.cmds().size() == 0); }
       THEN("positionals_amount should match the number of positionals added") {
-        REQUIRE(program.positionals_amount == 2);
+        REQUIRE(program.metadata.positionals_amount == 2);
       }
       THEN("positionals should be added as first arguments, but preserving the order of insertion") {
         REQUIRE(program.args()[0].name == "pos1");
@@ -224,7 +224,7 @@ SCENARIO("adding arguments", "[Program][args]") {
       THEN("the size of args should match the number of arguments added") { REQUIRE(program.args().size() == 5); }
       THEN("cmds should not be changed") { REQUIRE(program.cmds().size() == 0); }
       THEN("positionals_amount should match the number of positionals added") {
-        REQUIRE(program.positionals_amount == 5);
+        REQUIRE(program.metadata.positionals_amount == 5);
       }
       THEN("positionals should be added as first arguments, but preserving the order of insertion") {
         REQUIRE(program.args()[0].name == "pos5");
@@ -241,7 +241,7 @@ SCENARIO("adding arguments", "[Program][args]") {
       THEN("the size of args should match the number of arguments added") { REQUIRE(program.args().size() == 7); }
       THEN("cmds should not be changed") { REQUIRE(program.cmds().size() == 0); }
       THEN("positionals_amount should match the number of positionals added") {
-        REQUIRE(program.positionals_amount == 3);
+        REQUIRE(program.metadata.positionals_amount == 3);
       }
       THEN("positionals should be added as first arguments, but preserving the order of insertion") {
         REQUIRE(program.args()[0].name == "pos3");
@@ -250,7 +250,8 @@ SCENARIO("adding arguments", "[Program][args]") {
       }
       THEN("the rest of the arguments should be sorted lexicographically by name") {
         // also using is_sorted to check `operator<`
-        REQUIRE(std::is_sorted(std::next(program.args().begin(), program.positionals_amount), program.args().end()));
+        REQUIRE(std::is_sorted(std::next(program.args().begin(), program.metadata.positionals_amount),
+                               program.args().end()));
         REQUIRE(program.args()[3].name == "flg1");
         REQUIRE(program.args()[4].name == "flg2");
         REQUIRE(program.args()[5].name == "opt1");
@@ -266,7 +267,7 @@ SCENARIO("adding arguments", "[Program][args]") {
     THEN("the size of args should match the number of arguments added") { REQUIRE(program.args().size() == 7); }
     THEN("cmds should be empty") { REQUIRE(program.cmds().size() == 0); }
     THEN("positionals_amount should match the number of positionals added") {
-      REQUIRE(program.positionals_amount == 3);
+      REQUIRE(program.metadata.positionals_amount == 3);
     }
     THEN("positionals should be added as first arguments, but preserving the order of insertion") {
       REQUIRE(program.args()[0].name == "pos3");
@@ -275,7 +276,8 @@ SCENARIO("adding arguments", "[Program][args]") {
     }
     THEN("the rest of the arguments should be sorted lexicographically by name") {
       // also using is_sorted to check `operator<`
-      REQUIRE(std::is_sorted(std::next(program.args().begin(), program.positionals_amount), program.args().end()));
+      REQUIRE(
+          std::is_sorted(std::next(program.args().begin(), program.metadata.positionals_amount), program.args().end()));
       REQUIRE(program.args()[3].name == "flg1");
       REQUIRE(program.args()[4].name == "flg2");
       REQUIRE(program.args()[5].name == "opt1");
@@ -296,11 +298,11 @@ SCENARIO("adding commands", "[Program][cmds]") {
     THEN("they should initially have no arguments") {
       REQUIRE(program.args().size() == 0);
       REQUIRE(program.cmds().size() == 0);
-      REQUIRE(program.positionals_amount == 0);
+      REQUIRE(program.metadata.positionals_amount == 0);
 
       REQUIRE(cmd.args().size() == 0);
       REQUIRE(cmd.cmds().size() == 0);
-      REQUIRE(cmd.positionals_amount == 0);
+      REQUIRE(cmd.metadata.positionals_amount == 0);
     }
 
     WHEN("cmd is added as command of program") {
@@ -312,7 +314,7 @@ SCENARIO("adding commands", "[Program][cmds]") {
       }
       THEN("program's args should not be changed") {
         REQUIRE(program.args().size() == 0);
-        REQUIRE(program.positionals_amount == 0);
+        REQUIRE(program.metadata.positionals_amount == 0);
       }
 
       AND_WHEN("another command with the same name is added to program") {
@@ -330,7 +332,7 @@ SCENARIO("adding commands", "[Program][cmds]") {
         THEN("cmd2 should initially have no arguments") {
           REQUIRE(cmd2.args().size() == 0);
           REQUIRE(cmd2.cmds().size() == 0);
-          REQUIRE(cmd2.positionals_amount == 0);
+          REQUIRE(cmd2.metadata.positionals_amount == 0);
         }
 
         WHEN("cmd2 is added as command of program") {
@@ -343,7 +345,7 @@ SCENARIO("adding commands", "[Program][cmds]") {
           }
           THEN("program's args should not be changed") {
             REQUIRE(program.args().size() == 0);
-            REQUIRE(program.positionals_amount == 0);
+            REQUIRE(program.metadata.positionals_amount == 0);
           }
         }
       }
@@ -365,15 +367,15 @@ SCENARIO("adding commands", "[Program][cmds]") {
     THEN("they should initially have no arguments") {
       REQUIRE(program.args().size() == 0);
       REQUIRE(program.cmds().size() == 0);
-      REQUIRE(program.positionals_amount == 0);
+      REQUIRE(program.metadata.positionals_amount == 0);
 
       REQUIRE(cmd1.args().size() == 0);
       REQUIRE(cmd1.cmds().size() == 0);
-      REQUIRE(cmd1.positionals_amount == 0);
+      REQUIRE(cmd1.metadata.positionals_amount == 0);
 
       REQUIRE(cmd2.args().size() == 0);
       REQUIRE(cmd2.cmds().size() == 0);
-      REQUIRE(cmd2.positionals_amount == 0);
+      REQUIRE(cmd2.metadata.positionals_amount == 0);
     }
 
     WHEN("both are added as commands of program, but cmd2 first") {
@@ -386,7 +388,7 @@ SCENARIO("adding commands", "[Program][cmds]") {
       }
       THEN("program's args should not be changed") {
         REQUIRE(program.args().size() == 0);
-        REQUIRE(program.positionals_amount == 0);
+        REQUIRE(program.metadata.positionals_amount == 0);
       }
     }
   }
@@ -555,7 +557,7 @@ SCENARIO("parsing", "[Program][parsing]") {
         REQUIRE(map.as<std::string_view>("pos1") == std::string_view(argv[11]));
       }
 
-      AND_THEN("cmd_name should be set") { REQUIRE(map.cmd_name == cmd.name); }
+      AND_THEN("cmd_name should be set") { REQUIRE(map.cmd_name == cmd.metadata.name); }
       AND_THEN("cmd_args should have all the arguments of the command") {
         REQUIRE(map.cmd_args != nullptr);
 

--- a/tests/opzioni.program.cpp
+++ b/tests/opzioni.program.cpp
@@ -10,7 +10,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
   using namespace opzioni;
 
   GIVEN("a default-initialized Program") {
-    constexpr Program program;
+    constexpr auto program = Program();
 
     THEN("all member variables should have their defaults") {
       REQUIRE(program.metadata.name.empty());
@@ -26,7 +26,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
     }
 
     WHEN("intro is called") {
-      program.intro("intro");
+      constexpr auto program = Program().intro("intro");
 
       THEN("only the introduction should be changed") {
         REQUIRE(program.metadata.introduction == "intro");
@@ -43,7 +43,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
     }
 
     WHEN("details is called") {
-      program.details("details");
+      constexpr auto program = Program().details("details");
 
       THEN("only the description should be changed") {
         REQUIRE(program.metadata.description == "details");
@@ -60,7 +60,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
     }
 
     WHEN("version is called") {
-      program.version("1.0");
+      constexpr auto program = Program().version("1.0");
 
       THEN("only the version should be changed") {
         REQUIRE(program.metadata.version == "1.0");
@@ -77,7 +77,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
     }
 
     WHEN("intro, details, and version are called") {
-      program.intro("intro").details("details").version("1.0");
+      constexpr auto program = Program().intro("intro").details("details").version("1.0");
 
       THEN("all three should be changed") {
         REQUIRE(program.metadata.introduction == "intro");
@@ -94,7 +94,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
     }
 
     WHEN("max_width is called") {
-      program.max_width(80);
+      constexpr auto program = Program().max_width(80);
 
       THEN("only the msg_width should be changed") {
         REQUIRE(program.metadata.msg_width == 80);
@@ -111,7 +111,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
     }
 
     WHEN("on_error is called") {
-      program.on_error(nullptr);
+      constexpr auto program = Program().on_error(nullptr);
 
       THEN("only the error_handler should be changed") {
         REQUIRE(program.metadata.error_handler == nullptr);
@@ -128,7 +128,8 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
     }
 
     WHEN("intro, details, version, max_width, and on_error are called") {
-      program.intro("intro").details("details").version("1.0").max_width(80).on_error(nullptr);
+      constexpr auto program =
+          Program().intro("intro").details("details").version("1.0").max_width(80).on_error(nullptr);
 
       THEN("all five should be changed") {
         REQUIRE(program.metadata.introduction == "intro");
@@ -146,7 +147,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
   }
 
   GIVEN("a Program initialized with a name") {
-    constexpr Program program("program");
+    constexpr auto program = Program("program");
 
     THEN("only the name should not have its default value") {
       REQUIRE(program.metadata.name == "program");
@@ -163,7 +164,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
   }
 
   GIVEN("a Program initialized with a name and title") {
-    constexpr Program program("program", "title");
+    constexpr auto program = Program("program", "title");
 
     THEN("only name and title should not have their default values") {
       REQUIRE(program.metadata.name == "program");
@@ -438,61 +439,63 @@ SCENARIO("parsing", "[Program][parsing]") {
     }
   }
 
-//   GIVEN("a program with all kinds of arguments and a command") {
-//     constexpr auto cmd_args = Flg("f") * Pos("pos1") * Pos("cmd-pos") * Opt("long", "l");
-//     constexpr auto cmd = Program("cmd").on_error(rethrow) + cmd_args;
+  //   GIVEN("a program with all kinds of arguments and a command") {
+  //     constexpr auto cmd_args = Flg("f") * Pos("pos1") * Pos("cmd-pos") * Opt("long", "l");
+  //     constexpr auto cmd = Program("cmd").on_error(rethrow) + cmd_args;
 
-//     constexpr auto args = Pos("pos2") * Opt("long") * Flg("flg") * Opt("longer-opt", "l") * Pos("pos1") *
-//                           Flg("glf", "g") * Flg("f") * Opt("o");
-//     constexpr auto program = Program().on_error(rethrow) + args + cmd;
+  //     constexpr auto args = Pos("pos2") * Opt("long") * Flg("flg") * Opt("longer-opt", "l") * Pos("pos1") *
+  //                           Flg("glf", "g") * Flg("f") * Opt("o");
+  //     constexpr auto program = Program().on_error(rethrow) + args + cmd;
 
-//     WHEN("an empty argv is parsed") {
-//       std::array<char const *, 0> argv;
+  //     WHEN("an empty argv is parsed") {
+  //       std::array<char const *, 0> argv;
 
-//       THEN("we should throw an error because of missing required arguments") {
-//         REQUIRE_THROWS_AS(program(std::span(argv)), UserError);
-//       }
-//     }
+  //       THEN("we should throw an error because of missing required arguments") {
+  //         REQUIRE_THROWS_AS(program(std::span(argv)), UserError);
+  //       }
+  //     }
 
-//     AND_WHEN("an argv with only 1 element is parsed") {
-//       auto argv = std::array{"./program"};
+  //     AND_WHEN("an argv with only 1 element is parsed") {
+  //       auto argv = std::array{"./program"};
 
-//       THEN("we should throw an error because of missing required arguments") {
-//         REQUIRE_THROWS_AS(program(std::span(argv)), UserError);
-//       }
-//     }
+  //       THEN("we should throw an error because of missing required arguments") {
+  //         REQUIRE_THROWS_AS(program(std::span(argv)), UserError);
+  //       }
+  //     }
 
-//     AND_WHEN("all arguments are parsed, all long names, positionals given last") {
-//       auto argv =
-//           std::array{"./program", "--long", "long-val", "--flg", "--longer-opt", "longer-opt-val", "--glf", "-f", "-o",
-//                      "o-val",     "a",      "b",        "cmd",   "--long",       "long-val",       "-f",    "aa", "bb"};
+  //     AND_WHEN("all arguments are parsed, all long names, positionals given last") {
+  //       auto argv =
+  //           std::array{"./program", "--long", "long-val", "--flg", "--longer-opt", "longer-opt-val", "--glf", "-f",
+  //           "-o",
+  //                      "o-val",     "a",      "b",        "cmd",   "--long",       "long-val",       "-f",    "aa",
+  //                      "bb"};
 
-//       auto const map = program(std::span(argv));
+  //       auto const map = program(std::span(argv));
 
-//       THEN("exec_path should be set") { REQUIRE(map.exec_path == std::string_view(argv[0])); }
+  //       THEN("exec_path should be set") { REQUIRE(map.exec_path == std::string_view(argv[0])); }
 
-//       AND_THEN("args should have all the arguments of the main program") {
-//         REQUIRE(map.args.size() == args.size());
-//         REQUIRE(map.as<std::string_view>("long") == std::string_view(argv[2]));
-//         REQUIRE(map.as<bool>("flg") == true);
-//         REQUIRE(map.as<std::string_view>("longer-opt") == std::string_view(argv[5]));
-//         REQUIRE(map.as<bool>("glf") == true);
-//         REQUIRE(map.as<bool>("f") == true);
-//         REQUIRE(map.as<std::string_view>("o") == std::string_view(argv[9]));
-//         REQUIRE(map.as<std::string_view>("pos2") == std::string_view(argv[10]));
-//         REQUIRE(map.as<std::string_view>("pos1") == std::string_view(argv[11]));
-//       }
+  //       AND_THEN("args should have all the arguments of the main program") {
+  //         REQUIRE(map.args.size() == args.size());
+  //         REQUIRE(map.as<std::string_view>("long") == std::string_view(argv[2]));
+  //         REQUIRE(map.as<bool>("flg") == true);
+  //         REQUIRE(map.as<std::string_view>("longer-opt") == std::string_view(argv[5]));
+  //         REQUIRE(map.as<bool>("glf") == true);
+  //         REQUIRE(map.as<bool>("f") == true);
+  //         REQUIRE(map.as<std::string_view>("o") == std::string_view(argv[9]));
+  //         REQUIRE(map.as<std::string_view>("pos2") == std::string_view(argv[10]));
+  //         REQUIRE(map.as<std::string_view>("pos1") == std::string_view(argv[11]));
+  //       }
 
-//       AND_THEN("cmd_name should be set") { REQUIRE(map.cmd_name == cmd.metadata.name); }
-//       AND_THEN("cmd_args should have all the arguments of the command") {
-//         REQUIRE(map.cmd_args != nullptr);
+  //       AND_THEN("cmd_name should be set") { REQUIRE(map.cmd_name == cmd.metadata.name); }
+  //       AND_THEN("cmd_args should have all the arguments of the command") {
+  //         REQUIRE(map.cmd_args != nullptr);
 
-//         auto const &cmd_args = *map.cmd_args;
-//         REQUIRE(cmd_args.as<std::string_view>("long") == std::string_view(argv[14]));
-//         REQUIRE(cmd_args.as<bool>("f") == true);
-//         REQUIRE(cmd_args.as<std::string_view>("pos1") == std::string_view(argv[16]));
-//         REQUIRE(cmd_args.as<std::string_view>("cmd-pos") == std::string_view(argv[17]));
-//       }
-//     }
-//   }
+  //         auto const &cmd_args = *map.cmd_args;
+  //         REQUIRE(cmd_args.as<std::string_view>("long") == std::string_view(argv[14]));
+  //         REQUIRE(cmd_args.as<bool>("f") == true);
+  //         REQUIRE(cmd_args.as<std::string_view>("pos1") == std::string_view(argv[16]));
+  //         REQUIRE(cmd_args.as<std::string_view>("cmd-pos") == std::string_view(argv[17]));
+  //       }
+  //     }
+  //   }
 }

--- a/tests/opzioni.program.cpp
+++ b/tests/opzioni.program.cpp
@@ -256,70 +256,64 @@ SCENARIO("adding arguments", "[Program][args]") {
   }
 }
 
-// SCENARIO("adding commands", "[Program][cmds]") {
-//   using namespace opzioni;
-//   using namespace std::string_view_literals;
+SCENARIO("adding commands", "[Program][cmds]") {
+  using namespace opzioni;
+  using namespace std::string_view_literals;
 
-//   GIVEN("program and cmd") {
-//     constexpr auto cmd_name = "cmd"sv;
-//     constexpr Program cmd(cmd_name);
+  GIVEN("program and cmd") {
+    constexpr auto cmd_name = "cmd"sv;
+    constexpr static Program cmd(cmd_name);
 
-//     THEN("cmd should have no arguments") {
-//       REQUIRE(cmd.args.size() == 0);
-//       REQUIRE(cmd.cmds.size() == 0);
-//       REQUIRE(cmd.metadata.positionals_amount == 0);
-//     }
+    THEN("cmd should have no arguments") {
+      REQUIRE(cmd.args.size() == 0);
+      REQUIRE(cmd.cmds.size() == 0);
+      REQUIRE(cmd.metadata.positionals_amount == 0);
+    }
 
-//     WHEN("cmd is added as command of program") {
-//       constexpr auto program = Program() + std::array{Cmd(cmd)};
+    WHEN("cmd is added as command of program") {
+      constexpr auto program = Program() + std::array{ProgramView(cmd)};
 
-//       THEN("cmd should be added as only command of program") {
-//         REQUIRE(program.cmds.size() == 1);
-//         REQUIRE(program.cmds[0].metadata == cmd.metadata);
-//       }
-//       THEN("program's args should not be changed") {
-//         REQUIRE(program.args.size() == 0);
-//         REQUIRE(program.metadata.positionals_amount == 0);
-//       }
-//     }
+      THEN("cmd should be added as only command of program") {
+        REQUIRE(program.cmds.size() == 1);
+        REQUIRE(program.cmds[0].metadata == cmd.metadata);
+      }
+      THEN("program's args should not be changed") {
+        REQUIRE(program.args.size() == 0);
+        REQUIRE(program.metadata.positionals_amount == 0);
+      }
+    }
+  }
 
-//     AND_WHEN("cmd is added as command of program twice") {
-//       THEN("we should thow an error because of duplicate name") {
-//         REQUIRE_THROWS_AS(Program() + Cmd(cmd) * Cmd(cmd), ArgumentAlreadyExists);
-//       }
-//     }
-//   }
+  GIVEN("program, cmd1, and cmd2") {
+    constexpr auto cmd1_name = "cmd1"sv, cmd2_name = "cmd2"sv;
+    constexpr static Program cmd1(cmd1_name);
+    constexpr static Program cmd2(cmd2_name);
 
-//   GIVEN("program, cmd1, and cmd2") {
-//     constexpr auto cmd1_name = "cmd1"sv, cmd2_name = "cmd2"sv;
-//     constexpr Program cmd1(cmd1_name);
-//     constexpr Program cmd2(cmd2_name);
+    THEN("thee cmds should have no arguments") {
+      REQUIRE(cmd1.args.size() == 0);
+      REQUIRE(cmd1.cmds.size() == 0);
+      REQUIRE(cmd1.metadata.positionals_amount == 0);
 
-//     THEN("thee cmds should have no arguments") {
-//       REQUIRE(cmd1.args.size() == 0);
-//       REQUIRE(cmd1.cmds.size() == 0);
-//       REQUIRE(cmd1.metadata.positionals_amount == 0);
+      REQUIRE(cmd2.args.size() == 0);
+      REQUIRE(cmd2.cmds.size() == 0);
+      REQUIRE(cmd2.metadata.positionals_amount == 0);
+    }
 
-//       REQUIRE(cmd2.args.size() == 0);
-//       REQUIRE(cmd2.cmds.size() == 0);
-//       REQUIRE(cmd2.metadata.positionals_amount == 0);
-//     }
+    WHEN("both cmds are added as commands of program, but cmd2 first") {
+      constexpr auto program = Program() + cmd2 * cmd1;
 
-//     WHEN("both cmds are added as commands of program, but cmd2 first") {
-//       constexpr auto program = Program() + Cmd(cmd2) * Cmd(cmd1);
-
-//       THEN("cmd2 should be added as first command of program and cmd1 as second") {
-//         REQUIRE(program.cmds.size() == 2);
-//         REQUIRE(program.cmds[0].metadata == cmd2.metadata);
-//         REQUIRE(program.cmds[1].metadata == cmd1.metadata);
-//       }
-//       THEN("program's args should not be changed") {
-//         REQUIRE(program.args.size() == 0);
-//         REQUIRE(program.metadata.positionals_amount == 0);
-//       }
-//     }
-//   }
-// }
+      THEN("cmd1 should be added as first command of program and cmd2 as second") {
+        REQUIRE(program.cmds.size() == 2);
+        REQUIRE(program.cmds[0].metadata == cmd1.metadata);
+        REQUIRE(program.cmds[1].metadata == cmd2.metadata);
+      }
+      THEN("program's args should not be changed") {
+        REQUIRE(program.args.size() == 0);
+        REQUIRE(program.metadata.positionals_amount == 0);
+      }
+    }
+  }
+}
 
 SCENARIO("parsing", "[Program][parsing]") {
   using namespace opzioni;

--- a/tests/opzioni.program.cpp
+++ b/tests/opzioni.program.cpp
@@ -306,11 +306,11 @@ SCENARIO("adding commands", "[Program][cmds]") {
     }
 
     WHEN("cmd is added as command of program") {
-      program + Cmd(cmd);
+      program + cmd;
 
       THEN("cmd should be added as only command of program") {
         REQUIRE(program.cmds().size() == 1);
-        REQUIRE(program.cmds()[0].program == &cmd);
+        REQUIRE(program.cmds()[0].metadata == cmd.metadata);
       }
       THEN("program's args should not be changed") {
         REQUIRE(program.args().size() == 0);
@@ -321,7 +321,7 @@ SCENARIO("adding commands", "[Program][cmds]") {
         Program other_cmd("cmd");
 
         THEN("we should thow an error because of duplicate name") {
-          REQUIRE_THROWS_AS(program + Cmd(cmd) + Cmd(other_cmd), ArgumentAlreadyExists);
+          REQUIRE_THROWS_AS(program + cmd + other_cmd, ArgumentAlreadyExists);
         }
       }
 
@@ -336,12 +336,12 @@ SCENARIO("adding commands", "[Program][cmds]") {
         }
 
         WHEN("cmd2 is added as command of program") {
-          program + Cmd(cmd2);
+          program + cmd2;
 
           THEN("cmd2 should be added as second command of program") {
             REQUIRE(program.cmds().size() == 2);
-            REQUIRE(program.cmds()[0].program == &cmd);
-            REQUIRE(program.cmds()[1].program == &cmd2);
+            REQUIRE(program.cmds()[0].metadata == cmd.metadata);
+            REQUIRE(program.cmds()[1].metadata == cmd2.metadata);
           }
           THEN("program's args should not be changed") {
             REQUIRE(program.args().size() == 0);
@@ -353,7 +353,7 @@ SCENARIO("adding commands", "[Program][cmds]") {
 
     AND_WHEN("cmd is added as command of program twice") {
       THEN("we should thow an error because of duplicate name") {
-        REQUIRE_THROWS_AS(program + Cmd(cmd) + Cmd(cmd), ArgumentAlreadyExists);
+        REQUIRE_THROWS_AS(program + cmd + cmd, ArgumentAlreadyExists);
       }
     }
   }
@@ -379,12 +379,12 @@ SCENARIO("adding commands", "[Program][cmds]") {
     }
 
     WHEN("both are added as commands of program, but cmd2 first") {
-      program + Cmd(cmd2) + Cmd(cmd1);
+      program + cmd2 + cmd1;
 
       THEN("cmd2 should be added as first command of program and cmd1 as second") {
         REQUIRE(program.cmds().size() == 2);
-        REQUIRE(program.cmds()[0].program == &cmd2);
-        REQUIRE(program.cmds()[1].program == &cmd1);
+        REQUIRE(program.cmds()[0].metadata == cmd2.metadata);
+        REQUIRE(program.cmds()[1].metadata == cmd1.metadata);
       }
       THEN("program's args should not be changed") {
         REQUIRE(program.args().size() == 0);

--- a/tests/opzioni.program.cpp
+++ b/tests/opzioni.program.cpp
@@ -111,10 +111,10 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
     }
 
     WHEN("on_error is called") {
-      constexpr auto program = Program().on_error(nullptr);
+      constexpr auto program = Program().on_error(rethrow);
 
       THEN("only the error_handler should be changed") {
-        REQUIRE(program.metadata.error_handler == nullptr);
+        REQUIRE(program.metadata.error_handler == rethrow);
         REQUIRE(program.metadata.name.empty());
         REQUIRE(program.metadata.version.empty());
         REQUIRE(program.metadata.title.empty());
@@ -129,14 +129,14 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
 
     WHEN("intro, details, version, max_width, and on_error are called") {
       constexpr auto program =
-          Program().intro("intro").details("details").version("1.0").max_width(80).on_error(nullptr);
+          Program().intro("intro").details("details").version("1.0").max_width(80).on_error(print_error_and_usage);
 
       THEN("all five should be changed") {
         REQUIRE(program.metadata.introduction == "intro");
         REQUIRE(program.metadata.description == "details");
         REQUIRE(program.metadata.version == "1.0");
         REQUIRE(program.metadata.msg_width == 80);
-        REQUIRE(program.metadata.error_handler == nullptr);
+        REQUIRE(program.metadata.error_handler == print_error_and_usage);
         REQUIRE(program.metadata.name.empty());
         REQUIRE(program.metadata.title.empty());
         REQUIRE(program.metadata.positionals_amount == 0);

--- a/tests/opzioni.program.cpp
+++ b/tests/opzioni.program.cpp
@@ -324,7 +324,7 @@ SCENARIO("parsing", "[Program][parsing]") {
   using namespace opzioni;
 
   GIVEN("an empty Program") {
-    auto const program = Program().on_error(rethrow);
+    constexpr auto program = Program().on_error(rethrow);
 
     WHEN("an empty argv is parsed") {
       std::array<char const *, 0> argv;

--- a/tests/opzioni.program.cpp
+++ b/tests/opzioni.program.cpp
@@ -20,7 +20,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
       REQUIRE(program.metadata.description.empty());
       REQUIRE(program.metadata.msg_width == 100);
       REQUIRE(program.metadata.positionals_amount == 0);
-      REQUIRE(program.metadata.error_handler == print_error);
+      REQUIRE(program.metadata.error_handler == print_error_and_usage);
       REQUIRE(program.args.size() == 0);
       REQUIRE(program.cmds.size() == 0);
     }
@@ -36,7 +36,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
         REQUIRE(program.metadata.description.empty());
         REQUIRE(program.metadata.msg_width == 100);
         REQUIRE(program.metadata.positionals_amount == 0);
-        REQUIRE(program.metadata.error_handler == print_error);
+        REQUIRE(program.metadata.error_handler == print_error_and_usage);
         REQUIRE(program.args.size() == 0);
         REQUIRE(program.cmds.size() == 0);
       }
@@ -53,7 +53,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
         REQUIRE(program.metadata.introduction.empty());
         REQUIRE(program.metadata.msg_width == 100);
         REQUIRE(program.metadata.positionals_amount == 0);
-        REQUIRE(program.metadata.error_handler == print_error);
+        REQUIRE(program.metadata.error_handler == print_error_and_usage);
         REQUIRE(program.args.size() == 0);
         REQUIRE(program.cmds.size() == 0);
       }
@@ -70,7 +70,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
         REQUIRE(program.metadata.description.empty());
         REQUIRE(program.metadata.msg_width == 100);
         REQUIRE(program.metadata.positionals_amount == 0);
-        REQUIRE(program.metadata.error_handler == print_error);
+        REQUIRE(program.metadata.error_handler == print_error_and_usage);
         REQUIRE(program.args.size() == 0);
         REQUIRE(program.cmds.size() == 0);
       }
@@ -87,7 +87,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
         REQUIRE(program.metadata.title.empty());
         REQUIRE(program.metadata.msg_width == 100);
         REQUIRE(program.metadata.positionals_amount == 0);
-        REQUIRE(program.metadata.error_handler == print_error);
+        REQUIRE(program.metadata.error_handler == print_error_and_usage);
         REQUIRE(program.args.size() == 0);
         REQUIRE(program.cmds.size() == 0);
       }
@@ -104,7 +104,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
         REQUIRE(program.metadata.introduction.empty());
         REQUIRE(program.metadata.description.empty());
         REQUIRE(program.metadata.positionals_amount == 0);
-        REQUIRE(program.metadata.error_handler == print_error);
+        REQUIRE(program.metadata.error_handler == print_error_and_usage);
         REQUIRE(program.args.size() == 0);
         REQUIRE(program.cmds.size() == 0);
       }
@@ -129,14 +129,14 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
 
     WHEN("intro, details, version, max_width, and on_error are called") {
       constexpr auto program =
-          Program().intro("intro").details("details").version("1.0").max_width(80).on_error(print_error_and_usage);
+          Program().intro("intro").details("details").version("1.0").max_width(80).on_error(print_error);
 
       THEN("all five should be changed") {
         REQUIRE(program.metadata.introduction == "intro");
         REQUIRE(program.metadata.description == "details");
         REQUIRE(program.metadata.version == "1.0");
         REQUIRE(program.metadata.msg_width == 80);
-        REQUIRE(program.metadata.error_handler == print_error_and_usage);
+        REQUIRE(program.metadata.error_handler == print_error);
         REQUIRE(program.metadata.name.empty());
         REQUIRE(program.metadata.title.empty());
         REQUIRE(program.metadata.positionals_amount == 0);
@@ -157,7 +157,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
       REQUIRE(program.metadata.description.empty());
       REQUIRE(program.metadata.msg_width == 100);
       REQUIRE(program.metadata.positionals_amount == 0);
-      REQUIRE(program.metadata.error_handler == print_error);
+      REQUIRE(program.metadata.error_handler == print_error_and_usage);
       REQUIRE(program.args.size() == 0);
       REQUIRE(program.cmds.size() == 0);
     }
@@ -174,7 +174,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
       REQUIRE(program.metadata.description.empty());
       REQUIRE(program.metadata.msg_width == 100);
       REQUIRE(program.metadata.positionals_amount == 0);
-      REQUIRE(program.metadata.error_handler == print_error);
+      REQUIRE(program.metadata.error_handler == print_error_and_usage);
       REQUIRE(program.args.size() == 0);
       REQUIRE(program.cmds.size() == 0);
     }

--- a/tests/opzioni.program.cpp
+++ b/tests/opzioni.program.cpp
@@ -59,8 +59,8 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
       }
     }
 
-    WHEN("v is called") {
-      program.v("1.0");
+    WHEN("version is called") {
+      program.version("1.0");
 
       THEN("only the version should be changed") {
         REQUIRE(program.metadata.version == "1.0");
@@ -76,8 +76,8 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
       }
     }
 
-    WHEN("intro, details, and v are called") {
-      program.intro("intro").details("details").v("1.0");
+    WHEN("intro, details, and version are called") {
+      program.intro("intro").details("details").version("1.0");
 
       THEN("all three should be changed") {
         REQUIRE(program.metadata.introduction == "intro");
@@ -127,8 +127,8 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
       }
     }
 
-    WHEN("intro, details, v, max_width, and on_error are called") {
-      program.intro("intro").details("details").v("1.0").max_width(80).on_error(nullptr);
+    WHEN("intro, details, version, max_width, and on_error are called") {
+      program.intro("intro").details("details").version("1.0").max_width(80).on_error(nullptr);
 
       THEN("all five should be changed") {
         REQUIRE(program.metadata.introduction == "intro");

--- a/tests/opzioni.program.cpp
+++ b/tests/opzioni.program.cpp
@@ -433,63 +433,61 @@ SCENARIO("parsing", "[Program][parsing]") {
     }
   }
 
-  //   GIVEN("a program with all kinds of arguments and a command") {
-  //     constexpr auto cmd_args = Flg("f") * Pos("pos1") * Pos("cmd-pos") * Opt("long", "l");
-  //     constexpr auto cmd = Program("cmd").on_error(rethrow) + cmd_args;
+  GIVEN("a program with all kinds of arguments and a command") {
+    constexpr static auto cmd =
+        Program("cmd").on_error(rethrow) + Flg("f") * Pos("pos1") * Pos("cmd-pos") * Opt("long", "l");
 
-  //     constexpr auto args = Pos("pos2") * Opt("long") * Flg("flg") * Opt("longer-opt", "l") * Pos("pos1") *
-  //                           Flg("glf", "g") * Flg("f") * Opt("o");
-  //     constexpr auto program = Program().on_error(rethrow) + args + cmd;
+    constexpr auto program = Program().on_error(rethrow) + std::array{ProgramView(cmd)} +
+                             Pos("pos2") * Opt("long") * Flg("flg") * Opt("longer-opt", "l") * Pos("pos1") *
+                                 Flg("glf", "g") * Flg("f") * Opt("o");
 
-  //     WHEN("an empty argv is parsed") {
-  //       std::array<char const *, 0> argv;
+    WHEN("an empty argv is parsed") {
+      std::array<char const *, 0> argv;
 
-  //       THEN("we should throw an error because of missing required arguments") {
-  //         REQUIRE_THROWS_AS(program(std::span(argv)), UserError);
-  //       }
-  //     }
+      THEN("we should throw an error because of missing required arguments") {
+        REQUIRE_THROWS_AS(program(std::span(argv)), UserError);
+      }
+    }
 
-  //     AND_WHEN("an argv with only 1 element is parsed") {
-  //       auto argv = std::array{"./program"};
+    AND_WHEN("an argv with only 1 element is parsed") {
+      auto argv = std::array{"./program"};
 
-  //       THEN("we should throw an error because of missing required arguments") {
-  //         REQUIRE_THROWS_AS(program(std::span(argv)), UserError);
-  //       }
-  //     }
+      THEN("we should throw an error because of missing required arguments") {
+        REQUIRE_THROWS_AS(program(std::span(argv)), UserError);
+      }
+    }
 
-  //     AND_WHEN("all arguments are parsed, all long names, positionals given last") {
-  //       auto argv =
-  //           std::array{"./program", "--long", "long-val", "--flg", "--longer-opt", "longer-opt-val", "--glf", "-f",
-  //           "-o",
-  //                      "o-val",     "a",      "b",        "cmd",   "--long",       "long-val",       "-f",    "aa",
-  //                      "bb"};
+    AND_WHEN("all arguments are parsed, all long names, positionals given last") {
+      auto argv =
+          std::array{"./program", "--long", "long-val", "--flg", "--longer-opt", "longer-opt-val", "--glf", "-f", "-o",
+                     "o-val",     "a",      "b",        "cmd",   "--long",       "long-val",       "-f",    "aa", "bb"};
 
-  //       auto const map = program(std::span(argv));
+      auto const map = program(std::span(argv));
 
-  //       THEN("exec_path should be set") { REQUIRE(map.exec_path == std::string_view(argv[0])); }
+      THEN("exec_path should be set") { REQUIRE(map.exec_path == std::string_view(argv[0])); }
 
-  //       AND_THEN("args should have all the arguments of the main program") {
-  //         REQUIRE(map.args.size() == args.size());
-  //         REQUIRE(map.as<std::string_view>("long") == std::string_view(argv[2]));
-  //         REQUIRE(map.as<bool>("flg") == true);
-  //         REQUIRE(map.as<std::string_view>("longer-opt") == std::string_view(argv[5]));
-  //         REQUIRE(map.as<bool>("glf") == true);
-  //         REQUIRE(map.as<bool>("f") == true);
-  //         REQUIRE(map.as<std::string_view>("o") == std::string_view(argv[9]));
-  //         REQUIRE(map.as<std::string_view>("pos2") == std::string_view(argv[10]));
-  //         REQUIRE(map.as<std::string_view>("pos1") == std::string_view(argv[11]));
-  //       }
+      AND_THEN("args should have all the arguments of the main program") {
+        REQUIRE(map.args.size() == program.args.size());
+        REQUIRE(map.as<std::string_view>("long") == std::string_view(argv[2]));
+        REQUIRE(map.as<bool>("flg") == true);
+        REQUIRE(map.as<std::string_view>("longer-opt") == std::string_view(argv[5]));
+        REQUIRE(map.as<bool>("glf") == true);
+        REQUIRE(map.as<bool>("f") == true);
+        REQUIRE(map.as<std::string_view>("o") == std::string_view(argv[9]));
+        REQUIRE(map.as<std::string_view>("pos2") == std::string_view(argv[10]));
+        REQUIRE(map.as<std::string_view>("pos1") == std::string_view(argv[11]));
+      }
 
-  //       AND_THEN("cmd_name should be set") { REQUIRE(map.cmd_name == cmd.metadata.name); }
-  //       AND_THEN("cmd_args should have all the arguments of the command") {
-  //         REQUIRE(map.cmd_args != nullptr);
+      AND_THEN("cmd_name should be set") { REQUIRE(map.cmd_name == cmd.metadata.name); }
+      AND_THEN("cmd_args should have all the arguments of the command") {
+        REQUIRE(map.cmd_args != nullptr);
 
-  //         auto const &cmd_args = *map.cmd_args;
-  //         REQUIRE(cmd_args.as<std::string_view>("long") == std::string_view(argv[14]));
-  //         REQUIRE(cmd_args.as<bool>("f") == true);
-  //         REQUIRE(cmd_args.as<std::string_view>("pos1") == std::string_view(argv[16]));
-  //         REQUIRE(cmd_args.as<std::string_view>("cmd-pos") == std::string_view(argv[17]));
-  //       }
-  //     }
-  //   }
+        auto const &cmd_args = *map.cmd_args;
+        REQUIRE(cmd_args.as<std::string_view>("long") == std::string_view(argv[14]));
+        REQUIRE(cmd_args.as<bool>("f") == true);
+        REQUIRE(cmd_args.as<std::string_view>("pos1") == std::string_view(argv[16]));
+        REQUIRE(cmd_args.as<std::string_view>("cmd-pos") == std::string_view(argv[17]));
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Another big PR!

I finally found a way to make `Program` `constexpr`! :tada: 

**Thanks a lot for everyone that helped me in the C++ Slack, especially luke.**

In #43 I explained some of the problems I faced when trying to make `Program` `constexpr`. One of them was that it would become a templated class and then everything else that had to use it would have to deal with its template arguments. The solution I found was to implement something like a view (`ProgramView`, in fact), similar to `std::string_view` and `std::span`. In this view, I could store some kind of reference to the arrays of arguments and commands of a `Program`, but without the template parameters (I first used `std::span`, but it can't hold an incomplete type, so I had to go for pointers).

And then I faced another problem: after everything was implemented, for some reason the whole expression building a program was not `constexpr`. Turned out that to take the address of an object at compile-time demands that the object be marked `static`.

The rest, building the array of programs at compile-time and storing them at the main program, is very similar to what is done with the arguments. So similar that I also had to use `operator*` instead of `operator+` to build an array first because:

1. if I use `operator+` to build the array of arguments *and* and it to the main program, I'll actually never add it to the main program because it will also be added to the array and there will be no program left
2. if I always add the command to a program instead of first building an array, I never know when this will stop. And this is a big deal for both arguments and commands because I do expensive stuff when finally building the main program with all arguments and commands (like sorting and etc)

So:

- `Program` became templated on amount of args and amount of commands
- everywhere that took a `Program` as argument now takes a `ProgramView`
- added `ProgramMetadata` struct with all `Program`'s information except for array of arguments and commands. This is in order to `Program` and `ProgramView` to have the same data
- added `ProgramView` to be the "string view" of programs
- we now can validate duplicate command names at compile-time
- all member functions of `Program` are now marked `consteval`
- a program must always have an error handler, if it is not gonna be used. This is statically checked, so I removed the `nullptr` check when trying to use it
- all parsing-related stuff that were member of `Program` are now free functions
- rearranged some code so that things that don't need to be in the header are only in the source
- renamed `Program::v` to `Program::version`, since now there isn't already a `version` member
- changed default error handler to `print_error_and_usage` because it's nicer ;)
- `HelpFormatter` now only holds a `ProgramView` instead of a bunch of member variables
- added free function `parse` that allows the user to use their own `try... catch` (or not use any)