### PR TITLE
Rename csv_of to csv

### DIFF
--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -24,8 +24,8 @@ int main(int argc, char const *argv[]) {
           Opt("num", "n")
               .append<int>()
               .help("Creates a vector of numbers with each appearence of this argument. Default: {default_value}") *
-          Opt("csv").csv_of<int>().help("In contrast to `append`, this will create a vector of numbers from a single "
-                                        "comma-separated list of values. Default: {default_value}") *
+          Opt("csv").csv<int>().help("In contrast to `append`, this will create a vector of numbers from a single "
+                                     "comma-separated list of values. Default: {default_value}") *
           Opt("verbose", "v")
               .help("Level of verbosity. "
                     "Sets to {set_value} if given without a value (e.g. -{abbrev}). Default: {default_value}")

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -192,8 +192,8 @@ struct Arg {
     return arg;
   }
 
-  template <concepts::BuiltinType Elem>
-  consteval Arg csv_of() const noexcept {
+  template <concepts::BuiltinType Elem = std::string_view>
+  consteval Arg csv() const noexcept {
     if (this->type == ArgType::FLG)
       throw "Flags cannot use the csv action because they do not take values from the command-line";
     auto arg = Arg::With(*this, std::monostate{}, this->set_value);

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project(
     'opzioni', 'cpp',
-    version: '0.44.0',
+    version: '0.44.1',
     license: 'BSL-1.0',
     default_options: ['cpp_std=c++2a', 'buildtype=debug']
 )

--- a/test_package/meson.build
+++ b/test_package/meson.build
@@ -3,7 +3,7 @@ project(
     default_options: ['cpp_std=c++2a', 'buildtype=debug']
 )
 
-opzioni_dep = dependency('opzioni', version: '0.44.0')
+opzioni_dep = dependency('opzioni', version: '0.44.1')
 
 main = executable(
     'main', 'main.cpp',


### PR DESCRIPTION
Closes #48 

- renames `Arg::csv_of` to only `Arg::csv`
- adds `std::string_view` as default template argument for `Arg::csv`