### PR TITLE
Details

### DIFF
--- a/docs/src/user-guide/customization.md
+++ b/docs/src/user-guide/customization.md
@@ -110,9 +110,9 @@ Options & Flags:
     -h, --help    Display this information
 ```
 
-### `description`
+### `details`
 
-`description` is a piece of text that goes after the list of arguments.
+`details` is a piece of text that goes after the list of arguments.
 It can be used, for example, to add some details that weren't relevant before, like website, documentation, or contact information.
 It is specified via the `details` member function.
 

--- a/docs/src/user-guide/customization.md
+++ b/docs/src/user-guide/customization.md
@@ -110,6 +110,10 @@ Options & Flags:
     -h, --help    Display this information
 ```
 
+Just keep in mind that the introduction is used as a description for commands in the automatic help text of their parent program.
+In that case, an actual introduction is recommended.
+So an introduction like the example above is OK if the program is the root program.
+
 ### `details`
 
 `details` is a piece of text that goes after the list of arguments.

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -433,8 +433,9 @@ struct ProgramMetadata {
   std::string_view details{};
 
   std::size_t msg_width = 100;
-  std::size_t positionals_amount = 0;
   ErrorHandler error_handler = print_error_and_usage;
+
+  std::size_t positionals_amount = 0;
 
   constexpr auto operator<=>(ProgramMetadata const &) const noexcept = default;
 };

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -430,7 +430,7 @@ struct ProgramMetadata {
   std::string_view title{};
   std::string_view version{};
   std::string_view introduction{};
-  std::string_view description{};
+  std::string_view details{};
 
   std::size_t msg_width = 100;
   std::size_t positionals_amount = 0;
@@ -528,9 +528,9 @@ public:
     return program;
   }
 
-  consteval auto details(std::string_view description) const noexcept {
+  consteval auto details(std::string_view details) const noexcept {
     auto program = *this;
-    program.metadata.description = description;
+    program.metadata.details = details;
     return program;
   }
 
@@ -617,7 +617,7 @@ public:
   void print_intro() const noexcept;
   void print_long_usage() const noexcept;
   void print_help() const noexcept;
-  void print_description() const noexcept;
+  void print_details() const noexcept;
 
   std::size_t help_padding_size() const noexcept;
 

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project(
     'opzioni', 'cpp',
-    version: '0.44.5',
+    version: '0.45.0',
     license: 'BSL-1.0',
     default_options: ['cpp_std=c++2a', 'buildtype=debug']
 )

--- a/src/opzioni.cpp
+++ b/src/opzioni.cpp
@@ -373,7 +373,7 @@ void print_full_help(ProgramView const program, std::ostream &ostream) noexcept 
   ostream << nl;
   formatter.print_help();
   ostream << nl;
-  formatter.print_description();
+  formatter.print_details();
 }
 
 // +------------+
@@ -471,13 +471,13 @@ void HelpFormatter::print_help() const noexcept {
   }
 }
 
-void HelpFormatter::print_description() const noexcept {
-  if (program.metadata.description.empty())
+void HelpFormatter::print_details() const noexcept {
+  if (program.metadata.details.empty())
     return;
-  if (program.metadata.description.length() <= program.metadata.msg_width)
-    out << program.metadata.description << nl;
+  if (program.metadata.details.length() <= program.metadata.msg_width)
+    out << program.metadata.details << nl;
   else
-    out << limit_string_within(program.metadata.description, program.metadata.msg_width) << nl;
+    out << limit_string_within(program.metadata.details, program.metadata.msg_width) << nl;
 }
 
 // +---------------------------+

--- a/test_package/meson.build
+++ b/test_package/meson.build
@@ -3,7 +3,7 @@ project(
     default_options: ['cpp_std=c++2a', 'buildtype=debug']
 )
 
-opzioni_dep = dependency('opzioni', version: '0.44.5')
+opzioni_dep = dependency('opzioni', version: '0.45.0')
 
 main = executable(
     'main', 'main.cpp',

--- a/tests/opzioni.program.cpp
+++ b/tests/opzioni.program.cpp
@@ -17,7 +17,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
       REQUIRE(program.metadata.version.empty());
       REQUIRE(program.metadata.title.empty());
       REQUIRE(program.metadata.introduction.empty());
-      REQUIRE(program.metadata.description.empty());
+      REQUIRE(program.metadata.details.empty());
       REQUIRE(program.metadata.msg_width == 100);
       REQUIRE(program.metadata.positionals_amount == 0);
       REQUIRE(program.metadata.error_handler == print_error_and_usage);
@@ -33,7 +33,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
         REQUIRE(program.metadata.introduction == "intro");
         REQUIRE(program.metadata.version.empty());
         REQUIRE(program.metadata.title.empty());
-        REQUIRE(program.metadata.description.empty());
+        REQUIRE(program.metadata.details.empty());
         REQUIRE(program.metadata.msg_width == 100);
         REQUIRE(program.metadata.positionals_amount == 0);
         REQUIRE(program.metadata.error_handler == print_error_and_usage);
@@ -45,9 +45,9 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
     WHEN("details is called") {
       constexpr auto program = Program("program").details("details");
 
-      THEN("only the description should be changed") {
+      THEN("only the details should be changed") {
         REQUIRE(program.metadata.name == "program");
-        REQUIRE(program.metadata.description == "details");
+        REQUIRE(program.metadata.details == "details");
         REQUIRE(program.metadata.version.empty());
         REQUIRE(program.metadata.title.empty());
         REQUIRE(program.metadata.introduction.empty());
@@ -67,7 +67,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
         REQUIRE(program.metadata.version == "1.0");
         REQUIRE(program.metadata.title.empty());
         REQUIRE(program.metadata.introduction.empty());
-        REQUIRE(program.metadata.description.empty());
+        REQUIRE(program.metadata.details.empty());
         REQUIRE(program.metadata.msg_width == 100);
         REQUIRE(program.metadata.positionals_amount == 0);
         REQUIRE(program.metadata.error_handler == print_error_and_usage);
@@ -82,7 +82,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
       THEN("all three should be changed") {
         REQUIRE(program.metadata.name == "program");
         REQUIRE(program.metadata.introduction == "intro");
-        REQUIRE(program.metadata.description == "details");
+        REQUIRE(program.metadata.details == "details");
         REQUIRE(program.metadata.version == "1.0");
         REQUIRE(program.metadata.title.empty());
         REQUIRE(program.metadata.msg_width == 100);
@@ -102,7 +102,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
         REQUIRE(program.metadata.version.empty());
         REQUIRE(program.metadata.title.empty());
         REQUIRE(program.metadata.introduction.empty());
-        REQUIRE(program.metadata.description.empty());
+        REQUIRE(program.metadata.details.empty());
         REQUIRE(program.metadata.positionals_amount == 0);
         REQUIRE(program.metadata.error_handler == print_error_and_usage);
         REQUIRE(program.args.size() == 0);
@@ -119,7 +119,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
         REQUIRE(program.metadata.version.empty());
         REQUIRE(program.metadata.title.empty());
         REQUIRE(program.metadata.introduction.empty());
-        REQUIRE(program.metadata.description.empty());
+        REQUIRE(program.metadata.details.empty());
         REQUIRE(program.metadata.msg_width == 100);
         REQUIRE(program.metadata.positionals_amount == 0);
         REQUIRE(program.args.size() == 0);
@@ -134,7 +134,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
       THEN("all five should be changed") {
         REQUIRE(program.metadata.name == "program");
         REQUIRE(program.metadata.introduction == "intro");
-        REQUIRE(program.metadata.description == "details");
+        REQUIRE(program.metadata.details == "details");
         REQUIRE(program.metadata.version == "1.0");
         REQUIRE(program.metadata.msg_width == 80);
         REQUIRE(program.metadata.error_handler == print_error);
@@ -154,7 +154,7 @@ SCENARIO("setting general information", "[Program][defaults][info][setters]") {
       REQUIRE(program.metadata.title == "title");
       REQUIRE(program.metadata.version.empty());
       REQUIRE(program.metadata.introduction.empty());
-      REQUIRE(program.metadata.description.empty());
+      REQUIRE(program.metadata.details.empty());
       REQUIRE(program.metadata.msg_width == 100);
       REQUIRE(program.metadata.positionals_amount == 0);
       REQUIRE(program.metadata.error_handler == print_error_and_usage);


### PR DESCRIPTION
While writing the docs, I noticed that the `description` of `Program` is set via the `details` member function. Although the member function could now be called `description`, because the variable is inside `metadata` so the names wouldn't clash, I kinda didn't like the name, so I went for `details`. So now both the variable and the function are of the same name, just like `version`.

So:

- renamed `description` to `details` to match the member function
- renamed `HelpFormatter::print_description` to `print_details`
- updated the unit tests and docs

Did a few extra/unrelated things too:

- added a note in the docs about the introduction field
- moved around `positionals_amount` in `ProgramMetadata`. It was close to the other member variables, but that should not really be accessed by the user (mainly talking about modifying it), so I moved it to be the last member. I know it's not private and all, it just bothered me to be there