### PR TITLE
Checking validity of names

### DIFF
--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -340,7 +340,7 @@ consteval void validate_arg(Arg const &arg) noexcept {
     throw "Abbreviations must be a single character";
 
   if (!is_valid_name(arg.name))
-    throw "Argument names can only contain alphanumeric characters and - or _";
+    throw "Argument names can only contain alphanumeric characters and - or _ (but must not begin with - or _)";
 
   if (!is_valid_abbrev(arg.abbrev))
     throw "Argument abbreviations can only contain alphanumeric characters";

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -340,7 +340,8 @@ consteval void validate_arg(Arg const &arg) noexcept {
     throw "Abbreviations must be a single character";
 
   if (!is_valid_name(arg.name))
-    throw "Argument names can only contain alphanumeric characters and - or _ (and must begin with a letter)";
+    throw "Argument names can only contain alphanumeric characters and - or _,"
+          "and must begin with a letter and end with a letter or a number";
 
   if (!is_valid_abbrev(arg.abbrev))
     throw "Argument abbreviations can only contain alphanumeric characters";

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -330,6 +330,9 @@ consteval auto operator*(std::array<Arg, N> const args, Arg const other) noexcep
 }
 
 consteval void validate_arg(Arg const &arg) noexcept {
+  if (arg.name.empty())
+    throw "An argument cannot have an empty name";
+
   if (arg.type == ArgType::POS && arg.has_abbrev())
     throw "Positionals cannot have abbreviations";
 

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -525,7 +525,7 @@ public:
   consteval Program(std::string_view name) : Program(name, {}) {}
   consteval Program(std::string_view name, std::string_view title) : metadata{.name = name, .title = title} {
     if (!is_valid_name(name))
-      throw "Program names can only contain alphanumeric characters and - or _,"
+      throw "Program names cannot be empty, can only contain alphanumeric characters and - or _,"
             "and must begin with a letter and end with a letter or a number";
   }
 

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -340,7 +340,7 @@ consteval void validate_arg(Arg const &arg) noexcept {
     throw "Abbreviations must be a single character";
 
   if (!is_valid_name(arg.name))
-    throw "Argument names can only contain alphanumeric characters and - or _ (but must not begin with - or _)";
+    throw "Argument names can only contain alphanumeric characters and - or _ (and must begin with a letter)";
 
   if (!is_valid_abbrev(arg.abbrev))
     throw "Argument abbreviations can only contain alphanumeric characters";

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -523,7 +523,11 @@ public:
   std::array<ProgramView, CmdsSize> cmds;
 
   consteval Program(std::string_view name) : Program(name, {}) {}
-  consteval Program(std::string_view name, std::string_view title) : metadata{.name = name, .title = title} {}
+  consteval Program(std::string_view name, std::string_view title) : metadata{.name = name, .title = title} {
+    if (!is_valid_name(name))
+      throw "Program names can only contain alphanumeric characters and - or _,"
+            "and must begin with a letter and end with a letter or a number";
+  }
 
   template <std::size_t OtherArgsSize, std::size_t OtherCmdsSize>
   consteval Program(Program<OtherArgsSize, OtherCmdsSize> const &other) : metadata(other.metadata) {

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -340,9 +340,10 @@ consteval void validate_arg(Arg const &arg) noexcept {
     throw "Abbreviations must be a single letter";
 
   if (!is_valid_name(arg.name))
-    throw "Argument name is invalid. Names can only contain alphanumeric characters and - or _";
-  if (!is_valid_name(arg.abbrev))
-    throw "Argument abbreviation is invalid. Names can only contain alphanumeric characters and - or _";
+    throw "Argument names can only contain alphanumeric characters and - or _";
+
+  if (!is_valid_abbrev(arg.abbrev))
+    throw "Argument abbreviations can only contain alphanumeric characters";
 
   if (arg.type == ArgType::POS && arg.has_set())
     throw "Positionals cannot use set value because they always take a value from the command-line";

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -337,7 +337,7 @@ consteval void validate_arg(Arg const &arg) noexcept {
     throw "Positionals cannot have abbreviations";
 
   if (arg.has_abbrev() && arg.abbrev.length() != 1)
-    throw "Abbreviations must be a single letter";
+    throw "Abbreviations must be a single character";
 
   if (!is_valid_name(arg.name))
     throw "Argument names can only contain alphanumeric characters and - or _";

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -333,14 +333,19 @@ consteval void validate_arg(Arg const &arg) noexcept {
   if (arg.type == ArgType::POS && arg.has_abbrev())
     throw "Positionals cannot have abbreviations";
 
+  if (arg.has_abbrev() && arg.abbrev.length() != 1)
+    throw "Abbreviations must be a single letter";
+
+  if (!is_valid_name(arg.name))
+    throw "Argument name is invalid. Names can only contain alphanumeric characters and - or _";
+  if (!is_valid_name(arg.abbrev))
+    throw "Argument abbreviation is invalid. Names can only contain alphanumeric characters and - or _";
+
   if (arg.type == ArgType::POS && arg.has_set())
     throw "Positionals cannot use set value because they always take a value from the command-line";
 
   if (arg.type == ArgType::FLG && arg.gather_amount != 1) // 1 is the default
     throw "Flags cannot use gather because they do not take values from the command-line";
-
-  if (arg.has_abbrev() && arg.abbrev.length() != 1)
-    throw "Abbreviations must be a single letter";
 
   if (arg.is_required && arg.has_default())
     throw "A required argument cannot have a default value";
@@ -367,28 +372,30 @@ consteval void validate_args(std::array<Arg, N> const &args, Arg const &other) n
 // +----------------------+
 
 consteval Arg Flg(std::string_view name, std::string_view abbrev) noexcept {
-  if (!abbrev.empty() && abbrev.length() != 1)
-    throw "Abbreviations must be a single letter";
-  return Arg{.type = ArgType::FLG,
-             .name = name,
-             .abbrev = abbrev,
-             .default_value = false,
-             .set_value = true,
-             .action_fn = actions::assign<bool>};
+  auto const arg = Arg{.type = ArgType::FLG,
+                       .name = name,
+                       .abbrev = abbrev,
+                       .default_value = false,
+                       .set_value = true,
+                       .action_fn = actions::assign<bool>};
+  validate_arg(arg);
+  return arg;
 }
 
 consteval Arg Flg(std::string_view name) noexcept { return Flg(name, {}); }
 
 consteval Arg Opt(std::string_view name, std::string_view abbrev) noexcept {
-  if (!abbrev.empty() && abbrev.length() != 1)
-    throw "Abbreviations must be a single letter";
-  return Arg{.type = ArgType::OPT, .name = name, .abbrev = abbrev, .default_value = ""};
+  auto const arg = Arg{.type = ArgType::OPT, .name = name, .abbrev = abbrev, .default_value = ""};
+  validate_arg(arg);
+  return arg;
 }
 
 consteval Arg Opt(std::string_view name) noexcept { return Opt(name, {}); }
 
 consteval Arg Pos(std::string_view name) noexcept {
-  return Arg{.type = ArgType::POS, .name = name, .is_required = true};
+  auto const arg = Arg{.type = ArgType::POS, .name = name, .is_required = true};
+  validate_arg(arg);
+  return arg;
 }
 
 consteval Arg Help(std::string_view description) noexcept {

--- a/include/string.hpp
+++ b/include/string.hpp
@@ -1,6 +1,7 @@
 #ifndef OPZIONI_STRING_H
 #define OPZIONI_STRING_H
 
+#include <algorithm>
 #include <concepts>
 #include <string>
 #include <string_view>
@@ -10,6 +11,7 @@ namespace opzioni {
 
 constexpr char nl = '\n';
 constexpr std::string_view whitespace = " \f\n\r\t\v";
+constexpr std::string_view valid_name_chars = "0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZ-abcdefghijklmnopqrstuvwxyz";
 
 std::string_view trim(std::string_view) noexcept;
 
@@ -34,6 +36,14 @@ auto limit_within(std::ranges::range auto const &words, std::size_t const max_wi
 auto limit_within(std::string_view const, std::size_t const) noexcept -> std::vector<std::vector<std::string_view>>;
 
 std::string limit_string_within(std::string_view const, std::size_t const) noexcept;
+
+constexpr bool contains(std::string_view const str, char const ch) noexcept {
+  return str.find(ch) != std::string_view::npos;
+}
+
+constexpr bool is_valid_name(std::string_view name) noexcept {
+  return std::ranges::find_if(name, [](char const ch) { return !contains(valid_name_chars, ch); }) == name.end();
+}
 
 } // namespace opzioni
 

--- a/include/string.hpp
+++ b/include/string.hpp
@@ -43,8 +43,9 @@ constexpr bool contains(std::string_view const str, char const ch) noexcept {
 }
 
 constexpr bool is_valid_name(std::string_view name) noexcept {
-  // name is valid if there is no character that is not in `valid_name_chars`
-  return std::ranges::find_if(name, [](char const ch) { return !contains(valid_name_chars, ch); }) == name.end();
+  // name is valid if it doesn't begin with - or _ and there is no character in it that is not in `valid_name_chars`
+  return name.length() > 0 && name[0] != '-' && name[0] != '_' &&
+         std::ranges::find_if(name, [](char const ch) { return !contains(valid_name_chars, ch); }) == name.end();
 }
 
 constexpr bool is_valid_abbrev(std::string_view abbrev) noexcept {

--- a/include/string.hpp
+++ b/include/string.hpp
@@ -11,8 +11,6 @@ namespace opzioni {
 
 constexpr char nl = '\n';
 constexpr std::string_view whitespace = " \f\n\r\t\v";
-constexpr std::string_view valid_name_chars = "-_0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-constexpr std::string_view valid_abbrev_chars = valid_name_chars.substr(2);
 
 std::string_view trim(std::string_view) noexcept;
 
@@ -38,18 +36,19 @@ auto limit_within(std::string_view const, std::size_t const) noexcept -> std::ve
 
 std::string limit_string_within(std::string_view const, std::size_t const) noexcept;
 
-constexpr bool contains(std::string_view const str, char const ch) noexcept {
-  return str.find(ch) != std::string_view::npos;
-}
+constexpr bool is_alphabetic(char const ch) noexcept { return (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z'); }
+
+constexpr bool is_numeric(char const ch) noexcept { return ch >= '0' && ch <= '9'; }
 
 constexpr bool is_valid_name(std::string_view name) noexcept {
-  // name is valid if it begins with a letter and there is no character in it that is not in `valid_name_chars`
-  return name.length() > 0 && ((name[0] >= 'A' && name[0] <= 'Z') || (name[0] >= 'a' && name[0] <= 'z')) &&
-         std::ranges::find_if(name, [](char const ch) { return !contains(valid_name_chars, ch); }) == name.end();
+  return name.length() > 0 && is_alphabetic(name.front()) &&
+         (is_alphabetic(name.back()) || (name.length() > 1 && is_numeric(name.back()))) &&
+         std::ranges::all_of(
+             name, [](char const ch) { return is_alphabetic(ch) || is_numeric(ch) || ch == '-' || ch == '_'; });
 }
 
 constexpr bool is_valid_abbrev(std::string_view abbrev) noexcept {
-  return abbrev.length() == 0 || contains(valid_abbrev_chars, abbrev[0]);
+  return abbrev.length() == 0 || (abbrev.length() == 1 && (is_alphabetic(abbrev[0]) || is_numeric(abbrev[0])));
 }
 
 } // namespace opzioni

--- a/include/string.hpp
+++ b/include/string.hpp
@@ -11,7 +11,8 @@ namespace opzioni {
 
 constexpr char nl = '\n';
 constexpr std::string_view whitespace = " \f\n\r\t\v";
-constexpr std::string_view valid_name_chars = "0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZ-abcdefghijklmnopqrstuvwxyz";
+constexpr std::string_view valid_name_chars = "-_0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+constexpr std::string_view valid_abbrev_chars = valid_name_chars.substr(2);
 
 std::string_view trim(std::string_view) noexcept;
 
@@ -42,7 +43,12 @@ constexpr bool contains(std::string_view const str, char const ch) noexcept {
 }
 
 constexpr bool is_valid_name(std::string_view name) noexcept {
+  // name is valid if there is no character that is not in `valid_name_chars`
   return std::ranges::find_if(name, [](char const ch) { return !contains(valid_name_chars, ch); }) == name.end();
+}
+
+constexpr bool is_valid_abbrev(std::string_view abbrev) noexcept {
+  return abbrev.length() == 0 || contains(valid_abbrev_chars, abbrev[0]);
 }
 
 } // namespace opzioni

--- a/include/string.hpp
+++ b/include/string.hpp
@@ -43,8 +43,8 @@ constexpr bool contains(std::string_view const str, char const ch) noexcept {
 }
 
 constexpr bool is_valid_name(std::string_view name) noexcept {
-  // name is valid if it doesn't begin with - or _ and there is no character in it that is not in `valid_name_chars`
-  return name.length() > 0 && name[0] != '-' && name[0] != '_' &&
+  // name is valid if it begins with a letter and there is no character in it that is not in `valid_name_chars`
+  return name.length() > 0 && ((name[0] >= 'A' && name[0] <= 'Z') || (name[0] >= 'a' && name[0] <= 'z')) &&
          std::ranges::find_if(name, [](char const ch) { return !contains(valid_name_chars, ch); }) == name.end();
 }
 

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project(
     'opzioni', 'cpp',
-    version: '0.45.1',
+    version: '0.45.2',
     license: 'BSL-1.0',
     default_options: ['cpp_std=c++2a', 'buildtype=debug']
 )

--- a/test_package/meson.build
+++ b/test_package/meson.build
@@ -3,7 +3,7 @@ project(
     default_options: ['cpp_std=c++2a', 'buildtype=debug']
 )
 
-opzioni_dep = dependency('opzioni', version: '0.45.1')
+opzioni_dep = dependency('opzioni', version: '0.45.2')
 
 main = executable(
     'main', 'main.cpp',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -17,7 +17,13 @@ program_test = executable(
     ['catch2_main.cpp', 'opzioni.program.cpp'],
     dependencies: test_deps
 )
+string_test = executable(
+    'string',
+    ['catch2_main.cpp', 'string.cpp'],
+    dependencies: test_deps
+)
 
 test('arg', arg_test)
 test('converters', converters_test)
 test('program', program_test)
+test('string', string_test)

--- a/tests/string.cpp
+++ b/tests/string.cpp
@@ -227,3 +227,95 @@ SCENARIO("is_valid_name", "[string]") {
     REQUIRE(is_valid_name("a\\a") == false);
   }
 }
+
+SCENARIO("is_valid_abbrev", "[string]") {
+  using namespace opzioni;
+
+  GIVEN("valid abbreviations") {
+    REQUIRE(is_valid_abbrev("") == true);
+    REQUIRE(is_valid_abbrev("0") == true);
+    REQUIRE(is_valid_abbrev("1") == true);
+    REQUIRE(is_valid_abbrev("2") == true);
+    REQUIRE(is_valid_abbrev("3") == true);
+    REQUIRE(is_valid_abbrev("4") == true);
+    REQUIRE(is_valid_abbrev("5") == true);
+    REQUIRE(is_valid_abbrev("6") == true);
+    REQUIRE(is_valid_abbrev("7") == true);
+    REQUIRE(is_valid_abbrev("8") == true);
+    REQUIRE(is_valid_abbrev("9") == true);
+    REQUIRE(is_valid_abbrev("a") == true);
+    REQUIRE(is_valid_abbrev("A") == true);
+    REQUIRE(is_valid_abbrev("\0") == true); // apparently there's nothing I can do about this!?
+  }
+
+  GIVEN("invalid abbreviations") {
+    REQUIRE(is_valid_abbrev("-") == false);
+    REQUIRE(is_valid_abbrev("_") == false);
+
+    REQUIRE(is_valid_abbrev("`") == false);
+    REQUIRE(is_valid_abbrev("~") == false);
+    REQUIRE(is_valid_abbrev("!") == false);
+    REQUIRE(is_valid_abbrev("@") == false);
+    REQUIRE(is_valid_abbrev("#") == false);
+    REQUIRE(is_valid_abbrev("$") == false);
+    REQUIRE(is_valid_abbrev("%") == false);
+    REQUIRE(is_valid_abbrev("^") == false);
+    REQUIRE(is_valid_abbrev("&") == false);
+    REQUIRE(is_valid_abbrev("*") == false);
+    REQUIRE(is_valid_abbrev("(") == false);
+    REQUIRE(is_valid_abbrev(")") == false);
+    REQUIRE(is_valid_abbrev("=") == false);
+    REQUIRE(is_valid_abbrev("+") == false);
+    REQUIRE(is_valid_abbrev("[") == false);
+    REQUIRE(is_valid_abbrev("]") == false);
+    REQUIRE(is_valid_abbrev("{") == false);
+    REQUIRE(is_valid_abbrev("}") == false);
+    REQUIRE(is_valid_abbrev("|") == false);
+    REQUIRE(is_valid_abbrev(";") == false);
+    REQUIRE(is_valid_abbrev(":") == false);
+    REQUIRE(is_valid_abbrev("'") == false);
+    REQUIRE(is_valid_abbrev(",") == false);
+    REQUIRE(is_valid_abbrev(".") == false);
+    REQUIRE(is_valid_abbrev("<") == false);
+    REQUIRE(is_valid_abbrev(">") == false);
+    REQUIRE(is_valid_abbrev("/") == false);
+    REQUIRE(is_valid_abbrev("?") == false);
+    REQUIRE(is_valid_abbrev("\"") == false);
+    REQUIRE(is_valid_abbrev("\\") == false);
+
+    REQUIRE(is_valid_abbrev(" ") == false);
+    REQUIRE(is_valid_abbrev("\f") == false);
+    REQUIRE(is_valid_abbrev("\n") == false);
+    REQUIRE(is_valid_abbrev("\r") == false);
+    REQUIRE(is_valid_abbrev("\t") == false);
+    REQUIRE(is_valid_abbrev("\v") == false);
+
+    REQUIRE(is_valid_abbrev("aa") == false);
+    REQUIRE(is_valid_abbrev("aA") == false);
+    REQUIRE(is_valid_abbrev("a0") == false);
+    REQUIRE(is_valid_abbrev("a-") == false);
+    REQUIRE(is_valid_abbrev("a_") == false);
+    REQUIRE(is_valid_abbrev("a ") == false);
+
+    REQUIRE(is_valid_abbrev("Aa") == false);
+    REQUIRE(is_valid_abbrev("AA") == false);
+    REQUIRE(is_valid_abbrev("A0") == false);
+    REQUIRE(is_valid_abbrev("A-") == false);
+    REQUIRE(is_valid_abbrev("A_") == false);
+    REQUIRE(is_valid_abbrev("A ") == false);
+
+    REQUIRE(is_valid_abbrev("0a") == false);
+    REQUIRE(is_valid_abbrev("0A") == false);
+    REQUIRE(is_valid_abbrev("00") == false);
+    REQUIRE(is_valid_abbrev("0-") == false);
+    REQUIRE(is_valid_abbrev("0_") == false);
+    REQUIRE(is_valid_abbrev("0 ") == false);
+
+    REQUIRE(is_valid_abbrev(" a") == false);
+    REQUIRE(is_valid_abbrev(" A") == false);
+    REQUIRE(is_valid_abbrev(" 0") == false);
+    REQUIRE(is_valid_abbrev(" -") == false);
+    REQUIRE(is_valid_abbrev(" _") == false);
+    REQUIRE(is_valid_abbrev("  ") == false);
+  }
+}

--- a/tests/string.cpp
+++ b/tests/string.cpp
@@ -1,0 +1,229 @@
+#include <string_view>
+
+#include <catch2/catch.hpp>
+
+#include "string.hpp"
+
+// until we don't have fuzz testing...
+
+SCENARIO("is_valid_name", "[string]") {
+  using namespace opzioni;
+
+  GIVEN("valid names") {
+    REQUIRE(is_valid_name("a") == true);
+    REQUIRE(is_valid_name("A") == true);
+
+    REQUIRE(is_valid_name("aa") == true);
+    REQUIRE(is_valid_name("aA") == true);
+    REQUIRE(is_valid_name("Aa") == true);
+    REQUIRE(is_valid_name("AA") == true);
+
+    REQUIRE(is_valid_name("a0") == true);
+    REQUIRE(is_valid_name("A0") == true);
+    REQUIRE(is_valid_name("a0a") == true);
+    REQUIRE(is_valid_name("A0A") == true);
+
+    REQUIRE(is_valid_name("a-a") == true);
+    REQUIRE(is_valid_name("A-a") == true);
+    REQUIRE(is_valid_name("a-A") == true);
+    REQUIRE(is_valid_name("A-A") == true);
+
+    REQUIRE(is_valid_name("a_a") == true);
+    REQUIRE(is_valid_name("A_a") == true);
+    REQUIRE(is_valid_name("a_A") == true);
+    REQUIRE(is_valid_name("A_A") == true);
+
+    REQUIRE(is_valid_name("a-0") == true);
+    REQUIRE(is_valid_name("A-0") == true);
+    REQUIRE(is_valid_name("a_0") == true);
+    REQUIRE(is_valid_name("A_0") == true);
+  }
+
+  GIVEN("an empty name") { REQUIRE(is_valid_name("") == false); }
+
+  GIVEN("invalid names starting with numbers") {
+    REQUIRE(is_valid_name("0") == false);
+    REQUIRE(is_valid_name("1") == false);
+    REQUIRE(is_valid_name("2") == false);
+    REQUIRE(is_valid_name("3") == false);
+    REQUIRE(is_valid_name("4") == false);
+    REQUIRE(is_valid_name("5") == false);
+    REQUIRE(is_valid_name("6") == false);
+    REQUIRE(is_valid_name("7") == false);
+    REQUIRE(is_valid_name("8") == false);
+    REQUIRE(is_valid_name("9") == false);
+    REQUIRE(is_valid_name("00") == false);
+    REQUIRE(is_valid_name("0a") == false);
+  }
+
+  GIVEN("invalid names with -") {
+    REQUIRE(is_valid_name("-") == false);
+    REQUIRE(is_valid_name("--") == false);
+
+    REQUIRE(is_valid_name("a-") == false);
+    REQUIRE(is_valid_name("A-") == false);
+    REQUIRE(is_valid_name("0-") == false);
+
+    REQUIRE(is_valid_name("-a") == false);
+    REQUIRE(is_valid_name("-A") == false);
+    REQUIRE(is_valid_name("-0") == false);
+
+    REQUIRE(is_valid_name("-a-") == false);
+    REQUIRE(is_valid_name("-A-") == false);
+    REQUIRE(is_valid_name("-0-") == false);
+
+    REQUIRE(is_valid_name("0-a") == false);
+    REQUIRE(is_valid_name("0-A") == false);
+    REQUIRE(is_valid_name("0-0") == false);
+  }
+
+  GIVEN("invalid names with _") {
+    REQUIRE(is_valid_name("_") == false);
+    REQUIRE(is_valid_name("__") == false);
+
+    REQUIRE(is_valid_name("a_") == false);
+    REQUIRE(is_valid_name("A_") == false);
+    REQUIRE(is_valid_name("0_") == false);
+
+    REQUIRE(is_valid_name("_a") == false);
+    REQUIRE(is_valid_name("_A") == false);
+    REQUIRE(is_valid_name("_0") == false);
+
+    REQUIRE(is_valid_name("0_a") == false);
+    REQUIRE(is_valid_name("0_A") == false);
+    REQUIRE(is_valid_name("0_0") == false);
+  }
+
+  GIVEN("invalid names with - and _") {
+    REQUIRE(is_valid_name("-_") == false);
+    REQUIRE(is_valid_name("_-") == false);
+
+    REQUIRE(is_valid_name("-_-") == false);
+    REQUIRE(is_valid_name("_-_") == false);
+  }
+
+  GIVEN("names containing blanks") {
+    REQUIRE(is_valid_name(" ") == false);
+    REQUIRE(is_valid_name("  ") == false);
+    REQUIRE(is_valid_name("- ") == false);
+    REQUIRE(is_valid_name(" -") == false);
+    REQUIRE(is_valid_name("_ ") == false);
+    REQUIRE(is_valid_name(" _") == false);
+    REQUIRE(is_valid_name("a ") == false);
+    REQUIRE(is_valid_name(" a") == false);
+    REQUIRE(is_valid_name("0 ") == false);
+    REQUIRE(is_valid_name(" 0") == false);
+
+    REQUIRE(is_valid_name("a b") == false);
+
+    REQUIRE(is_valid_name("\n") == false);
+    REQUIRE(is_valid_name("a\n") == false);
+    REQUIRE(is_valid_name("\nb") == false);
+    REQUIRE(is_valid_name("a\nb") == false);
+
+    REQUIRE(is_valid_name("\t") == false);
+    REQUIRE(is_valid_name("a\t") == false);
+    REQUIRE(is_valid_name("\tb") == false);
+    REQUIRE(is_valid_name("a\tb") == false);
+
+    REQUIRE(is_valid_name("\r\n") == false);
+    REQUIRE(is_valid_name("a\r\n") == false);
+    REQUIRE(is_valid_name("\r\nb") == false);
+    REQUIRE(is_valid_name("a\r\nb") == false);
+  }
+
+  GIVEN("names containing other symbols") {
+    REQUIRE(is_valid_name("`") == false);
+    REQUIRE(is_valid_name("~") == false);
+    REQUIRE(is_valid_name("!") == false);
+    REQUIRE(is_valid_name("@") == false);
+    REQUIRE(is_valid_name("#") == false);
+    REQUIRE(is_valid_name("$") == false);
+    REQUIRE(is_valid_name("%") == false);
+    REQUIRE(is_valid_name("^") == false);
+    REQUIRE(is_valid_name("&") == false);
+    REQUIRE(is_valid_name("*") == false);
+    REQUIRE(is_valid_name("(") == false);
+    REQUIRE(is_valid_name(")") == false);
+    REQUIRE(is_valid_name("=") == false);
+    REQUIRE(is_valid_name("+") == false);
+    REQUIRE(is_valid_name("[") == false);
+    REQUIRE(is_valid_name("]") == false);
+    REQUIRE(is_valid_name("{") == false);
+    REQUIRE(is_valid_name("}") == false);
+    REQUIRE(is_valid_name("|") == false);
+    REQUIRE(is_valid_name(";") == false);
+    REQUIRE(is_valid_name(":") == false);
+    REQUIRE(is_valid_name("'") == false);
+    REQUIRE(is_valid_name(",") == false);
+    REQUIRE(is_valid_name(".") == false);
+    REQUIRE(is_valid_name("<") == false);
+    REQUIRE(is_valid_name(">") == false);
+    REQUIRE(is_valid_name("/") == false);
+    REQUIRE(is_valid_name("?") == false);
+    REQUIRE(is_valid_name("\"") == false);
+    REQUIRE(is_valid_name("\\") == false);
+
+    REQUIRE(is_valid_name("a`") == false);
+    REQUIRE(is_valid_name("a~") == false);
+    REQUIRE(is_valid_name("a!") == false);
+    REQUIRE(is_valid_name("a@") == false);
+    REQUIRE(is_valid_name("a#") == false);
+    REQUIRE(is_valid_name("a$") == false);
+    REQUIRE(is_valid_name("a%") == false);
+    REQUIRE(is_valid_name("a^") == false);
+    REQUIRE(is_valid_name("a&") == false);
+    REQUIRE(is_valid_name("a*") == false);
+    REQUIRE(is_valid_name("a(") == false);
+    REQUIRE(is_valid_name("a)") == false);
+    REQUIRE(is_valid_name("a=") == false);
+    REQUIRE(is_valid_name("a+") == false);
+    REQUIRE(is_valid_name("a[") == false);
+    REQUIRE(is_valid_name("a]") == false);
+    REQUIRE(is_valid_name("a{") == false);
+    REQUIRE(is_valid_name("a}") == false);
+    REQUIRE(is_valid_name("a|") == false);
+    REQUIRE(is_valid_name("a;") == false);
+    REQUIRE(is_valid_name("a:") == false);
+    REQUIRE(is_valid_name("a'") == false);
+    REQUIRE(is_valid_name("a,") == false);
+    REQUIRE(is_valid_name("a.") == false);
+    REQUIRE(is_valid_name("a<") == false);
+    REQUIRE(is_valid_name("a>") == false);
+    REQUIRE(is_valid_name("a/") == false);
+    REQUIRE(is_valid_name("a?") == false);
+    REQUIRE(is_valid_name("a\"") == false);
+    REQUIRE(is_valid_name("a\\") == false);
+
+    REQUIRE(is_valid_name("a`a") == false);
+    REQUIRE(is_valid_name("a~a") == false);
+    REQUIRE(is_valid_name("a!a") == false);
+    REQUIRE(is_valid_name("a@a") == false);
+    REQUIRE(is_valid_name("a#a") == false);
+    REQUIRE(is_valid_name("a$a") == false);
+    REQUIRE(is_valid_name("a%a") == false);
+    REQUIRE(is_valid_name("a^a") == false);
+    REQUIRE(is_valid_name("a&a") == false);
+    REQUIRE(is_valid_name("a*a") == false);
+    REQUIRE(is_valid_name("a(a") == false);
+    REQUIRE(is_valid_name("a)a") == false);
+    REQUIRE(is_valid_name("a=a") == false);
+    REQUIRE(is_valid_name("a+a") == false);
+    REQUIRE(is_valid_name("a[a") == false);
+    REQUIRE(is_valid_name("a]a") == false);
+    REQUIRE(is_valid_name("a{a") == false);
+    REQUIRE(is_valid_name("a}a") == false);
+    REQUIRE(is_valid_name("a|a") == false);
+    REQUIRE(is_valid_name("a;a") == false);
+    REQUIRE(is_valid_name("a:a") == false);
+    REQUIRE(is_valid_name("a'a") == false);
+    REQUIRE(is_valid_name("a,a") == false);
+    REQUIRE(is_valid_name("a.a") == false);
+    REQUIRE(is_valid_name("a<a") == false);
+    REQUIRE(is_valid_name("a>a") == false);
+    REQUIRE(is_valid_name("a/a") == false);
+    REQUIRE(is_valid_name("a?a") == false);
+    REQUIRE(is_valid_name("a\"a") == false);
+    REQUIRE(is_valid_name("a\\a") == false);
+  }
+}


### PR DESCRIPTION
- added `is_alphabetic`, which checks that a character is within `a-z` or `A-Z`
- added `is_numeric`, which checks that a character is within `0-9`
- added `is_valid_name`, which checks if a string:
    - is non-empty
    - first character `is_alphabetic`
    - last character `is_alphabetic`, or `is_numeric` if its length is > 1
    - all characters are alphabetic or numeric or `-` or `_`
- added `is_valid_abbrev`, which checks if a string is empty or is one character and it `is_alphabetic` or `is_numeric`

With that, added checks for validity of names of arguments and programs with `is_valid_name` and argument abbreviations with `is_valid_abbrev`. The check for empty argument name is separate to have a clearer message. Didn't think the same was necessary for programs.

Something "unrelated" that I've done is centralize the validations on `Arg` in the `validate_arg` function, so the factory functions construct an `Arg`, call `validate_arg` with it, and then return it.

Also added some unit tests to check that `is_valid_name` and `is_valid_abbrev` are somewhat correct. This is sorta provisional, since these functions require automated generation of input.