### PR TITLE
Rename set_value to implicit_value

### DIFF
--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -28,19 +28,20 @@ int main(int argc, char const *argv[]) {
                                      "comma-separated list of values. Default: {default_value}") *
           Opt("verbose", "v")
               .help("Level of verbosity. "
-                    "Sets to {set_value} if given without a value (e.g. -{abbrev}). Default: {default_value}")
-              .set(1)
+                    "Sets to {implicit_value} if given without a value (e.g. -{abbrev}). Default: {default_value}")
+              .implicitly(1)
               .otherwise(0) *
           Flg("append", "a")
-              .set(1)
+              .implicitly(1)
               .append<int>()
-              .help("The equivalent of Python's argparse `append_const`: will append {set_value} every time it "
+              .help("The equivalent of Python's argparse `append_const`: will append {implicit_value} every time it "
                     "appears in the CLI. Default: {default_value}") *
           Flg("flag", "f")
-              .set("do something!")
+              .implicitly("do something!")
               .otherwise("nope")
-              .help("The equivalent of Python's argparse `store_const`: will store \"{set_value}\" if it appears in "
-                    "the CLI. Default: {default_value}") *
+              .help(
+                  "The equivalent of Python's argparse `store_const`: will store \"{implicit_value}\" if it appears in "
+                  "the CLI. Default: {default_value}") *
           Flg("t").help("We also support flags with only short names. Default: {default_value}").otherwise(false);
 
   auto const args = program(argc, argv);

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -50,7 +50,7 @@ struct VectorOf<TypeList<Ts...>> {
   using type = TypeList<std::vector<Ts>...>;
 };
 
-// types that may be used as default_value and set_value
+// types that may be used as default_value and implicit_value
 using BuiltinTypes = TypeList<std::monostate, bool, int, double, std::string_view>;
 using BuiltinVariant = VariantOf<BuiltinTypes>::type;
 

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project(
     'opzioni', 'cpp',
-    version: '0.45.2',
+    version: '0.46.0',
     license: 'BSL-1.0',
     default_options: ['cpp_std=c++2a', 'buildtype=debug']
 )

--- a/src/opzioni.cpp
+++ b/src/opzioni.cpp
@@ -44,7 +44,7 @@ std::string Arg::format_base_usage() const noexcept {
   auto const dashes = name.length() > 1 ? "--" : "-";
   if (type == ArgType::OPT) {
     auto val = fmt::format("<{}>", has_abbrev() ? abbrev : name);
-    if (has_set())
+    if (has_implicit())
       val = "[" + val + "]";
     return fmt::format("{}{} {}", dashes, name, val);
   }
@@ -53,14 +53,14 @@ std::string Arg::format_base_usage() const noexcept {
 }
 
 std::string Arg::format_for_help_description() const noexcept {
-  auto const format = [this](auto const &default_value, auto const &set_value) {
+  auto const format = [this](auto const &default_value, auto const &implicit_value) {
     return fmt::format(description, fmt::arg("name", this->name), fmt::arg("abbrev", this->abbrev),
-                       fmt::arg("default_value", default_value), fmt::arg("set_value", set_value),
+                       fmt::arg("default_value", default_value), fmt::arg("implicit_value", implicit_value),
                        fmt::arg("gather_amount", this->gather_amount));
   };
   ArgValue default_value{};
   set_default_to(default_value); // gotta use this because of DefaultValueSetter
-  return std::visit(format, default_value.value, this->set_value);
+  return std::visit(format, default_value.value, this->implicit_value);
 }
 
 std::string Arg::format_for_help_index() const noexcept {
@@ -273,7 +273,7 @@ std::size_t assign_option(ProgramView const program, ArgMap &map, std::span<char
       ++count;
     } while (count < gather_amount);
     return gather_amount + 1;
-  } else if (arg.has_set()) {
+  } else if (arg.has_implicit()) {
     arg.action_fn(program, map, arg, std::nullopt);
     return 1;
   } else {

--- a/test_package/meson.build
+++ b/test_package/meson.build
@@ -3,7 +3,7 @@ project(
     default_options: ['cpp_std=c++2a', 'buildtype=debug']
 )
 
-opzioni_dep = dependency('opzioni', version: '0.45.2')
+opzioni_dep = dependency('opzioni', version: '0.46.0')
 
 main = executable(
     'main', 'main.cpp',

--- a/tests/opzioni.arg.cpp
+++ b/tests/opzioni.arg.cpp
@@ -16,7 +16,7 @@ SCENARIO("default values", "[Arg][defaults]") {
     THEN("description should be empty") { REQUIRE(arg.description.empty()); }
     THEN("is_required should be false") { REQUIRE(!arg.is_required); }
     THEN("default_value should be empty") { REQUIRE(std::holds_alternative<std::monostate>(arg.default_value)); }
-    THEN("set_value should be empty") { REQUIRE(std::holds_alternative<std::monostate>(arg.set_value)); }
+    THEN("implicit_value should be empty") { REQUIRE(std::holds_alternative<std::monostate>(arg.implicit_value)); }
     THEN("action_fn should be assign<string_view>") { REQUIRE(arg.action_fn == actions::assign<std::string_view>); }
     THEN("gather_amount should be 1") { REQUIRE(arg.gather_amount == 1); }
     THEN("default_setter should be nullptr") { REQUIRE(arg.default_setter == nullptr); }
@@ -31,7 +31,7 @@ SCENARIO("default values", "[Arg][defaults]") {
     THEN("description should be empty") { REQUIRE(arg.description.empty()); }
     THEN("is_required should be false") { REQUIRE(!arg.is_required); }
     THEN("default_value should be false") { REQUIRE(std::get<bool>(arg.default_value) == false); }
-    THEN("set_value should be true") { REQUIRE(std::get<bool>(arg.set_value) == true); }
+    THEN("implicit_value should be true") { REQUIRE(std::get<bool>(arg.implicit_value) == true); }
     THEN("action_fn should be assign<bool>") { REQUIRE(arg.action_fn == actions::assign<bool>); }
     THEN("gather_amount should be 1") { REQUIRE(arg.gather_amount == 1); }
     THEN("default_setter should be nullptr") { REQUIRE(arg.default_setter == nullptr); }
@@ -46,7 +46,7 @@ SCENARIO("default values", "[Arg][defaults]") {
     THEN("description should be empty") { REQUIRE(arg.description.empty()); }
     THEN("is_required should be false") { REQUIRE(!arg.is_required); }
     THEN("default_value should be false") { REQUIRE(std::get<bool>(arg.default_value) == false); }
-    THEN("set_value should be true") { REQUIRE(std::get<bool>(arg.set_value) == true); }
+    THEN("implicit_value should be true") { REQUIRE(std::get<bool>(arg.implicit_value) == true); }
     THEN("action_fn should be assign<bool>") { REQUIRE(arg.action_fn == actions::assign<bool>); }
     THEN("gather_amount should be 1") { REQUIRE(arg.gather_amount == 1); }
     THEN("default_setter should be nullptr") { REQUIRE(arg.default_setter == nullptr); }
@@ -61,7 +61,7 @@ SCENARIO("default values", "[Arg][defaults]") {
     THEN("description should be empty") { REQUIRE(arg.description.empty()); }
     THEN("is_required should be false") { REQUIRE(!arg.is_required); }
     THEN("default_value should be empty string") { REQUIRE(std::get<std::string_view>(arg.default_value) == ""); }
-    THEN("set_value should be empty") { REQUIRE(std::holds_alternative<std::monostate>(arg.set_value)); }
+    THEN("implicit_value should be empty") { REQUIRE(std::holds_alternative<std::monostate>(arg.implicit_value)); }
     THEN("action_fn should be assign<string_view>") { REQUIRE(arg.action_fn == actions::assign<std::string_view>); }
     THEN("gather_amount should be 1") { REQUIRE(arg.gather_amount == 1); }
     THEN("default_setter should be nullptr") { REQUIRE(arg.default_setter == nullptr); }
@@ -76,7 +76,7 @@ SCENARIO("default values", "[Arg][defaults]") {
     THEN("description should be empty") { REQUIRE(arg.description.empty()); }
     THEN("is_required should be false") { REQUIRE(!arg.is_required); }
     THEN("default_value should be empty string") { REQUIRE(std::get<std::string_view>(arg.default_value) == ""); }
-    THEN("set_value should be empty") { REQUIRE(std::holds_alternative<std::monostate>(arg.set_value)); }
+    THEN("implicit_value should be empty") { REQUIRE(std::holds_alternative<std::monostate>(arg.implicit_value)); }
     THEN("action_fn should be assign<string_view>") { REQUIRE(arg.action_fn == actions::assign<std::string_view>); }
     THEN("gather_amount should be 1") { REQUIRE(arg.gather_amount == 1); }
     THEN("default_setter should be nullptr") { REQUIRE(arg.default_setter == nullptr); }
@@ -91,7 +91,7 @@ SCENARIO("default values", "[Arg][defaults]") {
     THEN("description should be empty") { REQUIRE(arg.description.empty()); }
     THEN("is_required should be true") { REQUIRE(arg.is_required); }
     THEN("default_value should be empty") { REQUIRE(std::holds_alternative<std::monostate>(arg.default_value)); }
-    THEN("set_value should be empty") { REQUIRE(std::holds_alternative<std::monostate>(arg.set_value)); }
+    THEN("implicit_value should be empty") { REQUIRE(std::holds_alternative<std::monostate>(arg.implicit_value)); }
     THEN("action_fn should be assign<string_view>") { REQUIRE(arg.action_fn == actions::assign<std::string_view>); }
     THEN("gather_amount should be 1") { REQUIRE(arg.gather_amount == 1); }
     THEN("default_setter should be nullptr") { REQUIRE(arg.default_setter == nullptr); }
@@ -106,7 +106,7 @@ SCENARIO("default values", "[Arg][defaults]") {
     THEN("description should be the default") { REQUIRE(arg.description == "Display this information"); }
     THEN("is_required should be false") { REQUIRE(!arg.is_required); }
     THEN("default_value should be false") { REQUIRE(std::get<bool>(arg.default_value) == false); }
-    THEN("set_value should be true") { REQUIRE(std::get<bool>(arg.set_value) == true); }
+    THEN("implicit_value should be true") { REQUIRE(std::get<bool>(arg.implicit_value) == true); }
     THEN("action_fn should be print_help") { REQUIRE(arg.action_fn == actions::print_help); }
     THEN("gather_amount should be 1") { REQUIRE(arg.gather_amount == 1); }
     THEN("default_setter should be nullptr") { REQUIRE(arg.default_setter == nullptr); }
@@ -121,7 +121,7 @@ SCENARIO("default values", "[Arg][defaults]") {
     THEN("description should be equal to argument") { REQUIRE(arg.description == "Display this help text and exit"); }
     THEN("is_required should be false") { REQUIRE(!arg.is_required); }
     THEN("default_value should be false") { REQUIRE(std::get<bool>(arg.default_value) == false); }
-    THEN("set_value should be true") { REQUIRE(std::get<bool>(arg.set_value) == true); }
+    THEN("implicit_value should be true") { REQUIRE(std::get<bool>(arg.implicit_value) == true); }
     THEN("action_fn should be print_help") { REQUIRE(arg.action_fn == actions::print_help); }
     THEN("gather_amount should be 1") { REQUIRE(arg.gather_amount == 1); }
     THEN("default_setter should be nullptr") { REQUIRE(arg.default_setter == nullptr); }
@@ -136,7 +136,7 @@ SCENARIO("default values", "[Arg][defaults]") {
     THEN("description should be the default") { REQUIRE(arg.description == "Display the software version"); }
     THEN("is_required should be false") { REQUIRE(!arg.is_required); }
     THEN("default_value should be false") { REQUIRE(std::get<bool>(arg.default_value) == false); }
-    THEN("set_value should be true") { REQUIRE(std::get<bool>(arg.set_value) == true); }
+    THEN("implicit_value should be true") { REQUIRE(std::get<bool>(arg.implicit_value) == true); }
     THEN("action_fn should be print_version") { REQUIRE(arg.action_fn == actions::print_version); }
     THEN("gather_amount should be 1") { REQUIRE(arg.gather_amount == 1); }
     THEN("default_setter should be nullptr") { REQUIRE(arg.default_setter == nullptr); }
@@ -151,7 +151,7 @@ SCENARIO("default values", "[Arg][defaults]") {
     THEN("description should be equal to argument") { REQUIRE(arg.description == "Show the version of this program"); }
     THEN("is_required should be false") { REQUIRE(!arg.is_required); }
     THEN("default_value should be false") { REQUIRE(std::get<bool>(arg.default_value) == false); }
-    THEN("set_value should be true") { REQUIRE(std::get<bool>(arg.set_value) == true); }
+    THEN("implicit_value should be true") { REQUIRE(std::get<bool>(arg.implicit_value) == true); }
     THEN("action_fn should be print_version") { REQUIRE(arg.action_fn == actions::print_version); }
     THEN("gather_amount should be 1") { REQUIRE(arg.gather_amount == 1); }
     THEN("default_setter should be nullptr") { REQUIRE(arg.default_setter == nullptr); }
@@ -257,32 +257,32 @@ SCENARIO("has_default", "[Arg]") {
   }
 }
 
-SCENARIO("has_set", "[Arg]") {
+SCENARIO("has_implicit", "[Arg]") {
   using namespace opzioni;
 
-  GIVEN("an Arg with a default-constructed set_value") {
-    constexpr auto arg = Arg{.set_value{}};
-    THEN("has_set should return false") { REQUIRE(!arg.has_set()); }
+  GIVEN("an Arg with a default-constructed implicit_value") {
+    constexpr auto arg = Arg{.implicit_value{}};
+    THEN("has_implicit should return false") { REQUIRE(!arg.has_implicit()); }
   }
 
-  GIVEN("an Arg with a set_value explicitly set to monostate") {
-    constexpr auto arg = Arg{.set_value = std::monostate{}};
-    THEN("has_set should return false") { REQUIRE(!arg.has_set()); }
+  GIVEN("an Arg with a implicit_value explicitly set to monostate") {
+    constexpr auto arg = Arg{.implicit_value = std::monostate{}};
+    THEN("has_implicit should return false") { REQUIRE(!arg.has_implicit()); }
   }
 
-  GIVEN("an Arg with a set_value set to zero") {
-    constexpr auto arg = Arg{.set_value = 0};
-    THEN("has_set should return true") { REQUIRE(arg.has_set()); }
+  GIVEN("an Arg with a implicit_value set to zero") {
+    constexpr auto arg = Arg{.implicit_value = 0};
+    THEN("has_implicit should return true") { REQUIRE(arg.has_implicit()); }
   }
 
-  GIVEN("an Arg with a set_value set to empty string") {
-    constexpr auto arg = Arg{.set_value = ""};
-    THEN("has_set should return true") { REQUIRE(arg.has_set()); }
+  GIVEN("an Arg with a implicit_value set to empty string") {
+    constexpr auto arg = Arg{.implicit_value = ""};
+    THEN("has_implicit should return true") { REQUIRE(arg.has_implicit()); }
   }
 
-  GIVEN("an Arg with a set_value set to false") {
-    constexpr auto arg = Arg{.set_value = false};
-    THEN("has_set should return true") { REQUIRE(arg.has_set()); }
+  GIVEN("an Arg with a implicit_value set to false") {
+    constexpr auto arg = Arg{.implicit_value = false};
+    THEN("has_implicit should return true") { REQUIRE(arg.has_implicit()); }
   }
 }
 


### PR DESCRIPTION
Closes #56 

Simply renamed `set_value` to `implicit_value`, without any change in semantics or functionality.
`Arg::set` was renamed to `Arg::implicitly`.