### PR TITLE
Count action

### DIFF
--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -60,5 +60,5 @@ int main(int argc, char const *argv[]) {
 
   print("append: {}\n", args.has("append") ? args.as<std::vector<int>>("append") : std::vector<int>{});
   print("flag: {}\n", args.as<std::string_view>("flag"));
-  print("t: {}\n", args.as<int>("t"));
+  print("t: {}\n", args.as<std::size_t>("t"));
 }

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char const *argv[]) {
               .help(
                   "The equivalent of Python's argparse `store_const`: will store \"{implicit_value}\" if it appears in "
                   "the CLI. Default: {default_value}") *
-          Flg("t").help("We also support flags with only short names. Default: {default_value}").otherwise(false);
+          Flg("t").help("We also support flags with only short names. Default: {default_value}").count();
 
   auto const args = program(argc, argv);
   print("\nCommand path: {}\n", args.exec_path);
@@ -60,5 +60,5 @@ int main(int argc, char const *argv[]) {
 
   print("append: {}\n", args.has("append") ? args.as<std::vector<int>>("append") : std::vector<int>{});
   print("flag: {}\n", args.as<std::string_view>("flag"));
-  print("t: {}\n", args.as<bool>("t"));
+  print("t: {}\n", args.as<int>("t"));
 }

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -42,7 +42,8 @@ int main(int argc, char const *argv[]) {
               .help(
                   "The equivalent of Python's argparse `store_const`: will store \"{implicit_value}\" if it appears in "
                   "the CLI. Default: {default_value}") *
-          Flg("t").help("We also support flags with only short names. Default: {default_value}").count();
+          Flg("t").count().help("We also support flags with only short names. This argument counts how many times it "
+                                "appears in the CLI. Default: {default_value}");
 
   auto const args = program(argc, argv);
   print("\nCommand path: {}\n", args.exec_path);

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -198,7 +198,7 @@ struct Arg {
       throw "Count arguments must be flags";
     auto arg = Arg::With(*this, std::monostate{}, std::monostate{});
     if (!this->is_required)
-      arg = arg.otherwise(0);
+      arg = arg.otherwise(std::size_t{0});
     arg.action_fn = actions::count;
     return arg;
   }
@@ -722,9 +722,9 @@ void append(ProgramView const, ArgMap &map, Arg const &arg, std::optional<std::s
 // +-------+
 
 void count(ProgramView const, ArgMap &map, Arg const &arg, std::optional<std::string_view> const parsed_value) {
-  auto [it, inserted] = map.args.try_emplace(arg.name, 1);
+  auto [it, inserted] = map.args.try_emplace(arg.name, std::size_t{1});
   if (!inserted)
-    it->second.value = std::get<int>(it->second.value) + 1;
+    it->second.value = std::get<std::size_t>(it->second.value) + 1;
 }
 
 // +-----+

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -197,10 +197,10 @@ struct Arg {
     if (this->type != ArgType::FLG)
       throw "Count arguments must be flags";
     auto arg = Arg::With(*this, std::monostate{}, std::monostate{});
+    if (!this->is_required)
+      arg = arg.otherwise(0);
     arg.action_fn = actions::count;
-    if (this->is_required)
-      return arg;
-    return arg.otherwise(0);
+    return arg;
   }
 
   template <concepts::BuiltinType Elem = std::string_view>
@@ -247,7 +247,7 @@ struct Arg {
   template <concepts::BuiltinType T>
   consteval Arg otherwise(T value) const noexcept {
     auto arg = Arg::With(*this, value, this->implicit_value);
-    //    arg.action_fn = actions::assign<T>;
+    arg.action_fn = actions::assign<T>;
     arg.default_setter = nullptr;
     arg.is_required = false;
     return arg;

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -717,16 +717,6 @@ void append(ProgramView const, ArgMap &map, Arg const &arg, std::optional<std::s
     append_to<Elem>(map, arg.name, std::get<Elem>(arg.implicit_value));
 }
 
-// +-------+
-// | count |
-// +-------+
-
-void count(ProgramView const, ArgMap &map, Arg const &arg, std::optional<std::string_view> const parsed_value) {
-  auto [it, inserted] = map.args.try_emplace(arg.name, std::size_t{1});
-  if (!inserted)
-    it->second.value = std::get<std::size_t>(it->second.value) + 1;
-}
-
 // +-----+
 // | csv |
 // +-----+

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -51,7 +51,7 @@ struct VectorOf<TypeList<Ts...>> {
 };
 
 // types that may be used as default_value and implicit_value
-using BuiltinTypes = TypeList<std::monostate, bool, int, double, std::string_view>;
+using BuiltinTypes = TypeList<std::monostate, bool, int, double, std::size_t, std::string_view>;
 using BuiltinVariant = VariantOf<BuiltinTypes>::type;
 
 // types that may be the result of parsing the CLI

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project(
     'opzioni', 'cpp',
-    version: '0.46.0',
+    version: '0.47.0',
     license: 'BSL-1.0',
     default_options: ['cpp_std=c++2a', 'buildtype=debug']
 )

--- a/src/opzioni.cpp
+++ b/src/opzioni.cpp
@@ -486,6 +486,12 @@ void HelpFormatter::print_details() const noexcept {
 
 namespace actions {
 
+void count(ProgramView const, ArgMap &map, Arg const &arg, std::optional<std::string_view> const parsed_value) {
+  auto [it, inserted] = map.args.try_emplace(arg.name, std::size_t{1});
+  if (!inserted)
+    it->second.value = std::get<std::size_t>(it->second.value) + 1;
+}
+
 void print_help(ProgramView const program, ArgMap &, Arg const &, std::optional<std::string_view> const) {
   print_full_help(program);
   std::exit(0);

--- a/test_package/meson.build
+++ b/test_package/meson.build
@@ -3,7 +3,7 @@ project(
     default_options: ['cpp_std=c++2a', 'buildtype=debug']
 )
 
-opzioni_dep = dependency('opzioni', version: '0.46.0')
+opzioni_dep = dependency('opzioni', version: '0.47.0')
 
 main = executable(
     'main', 'main.cpp',


### PR DESCRIPTION
- added count action of uncustomizable type `std::size_t`
- added `std::size_t` to BuiltinTypes
- added helper `Arg::count` function, similar to `gather` and `csv`
- updated main example to make `t` use the new action