### PR TITLE
feat: specify actions in square brackets

### DIFF
--- a/examples/docker.cpp
+++ b/examples/docker.cpp
@@ -19,18 +19,19 @@ using vec = std::vector<T>;
 int main(int argc, char const *argv[]) {
   using namespace opzioni;
 
-  constexpr static auto exec = Program("exec").intro("Run a command in a running container") +
-                               Help() * Flg("detach", "d").help("Detached mode: run command in the background") *
-                                   Opt("detach-keys").help("Override the key sequence for detaching a container") *
-                                   Opt("env", "e").help("Set environment variables").append() *
-                                   Opt("env-file").help("Read in a file of environment variables").append() *
-                                   Flg("interactive", "i").help("Keep STDIN open even if not attached") *
-                                   Flg("privileged").help("Give extended privileges to the command") *
-                                   Flg("tty", "t").help("Allocate a pseudo-TTY") *
-                                   Opt("user", "u").help("Username or UID (format: <name|uid>[:<group|gid>])") *
-                                   Opt("workdir", "w").help("Working directory inside the container") *
-                                   Pos("container").help("Name of the target container") *
-                                   Pos("command").help("The command to run in the container").gather();
+  constexpr static auto exec =
+      Program("exec").intro("Run a command in a running container") +
+      Help() * Flg("detach", "d").help("Detached mode: run command in the background") *
+          Opt("detach-keys").help("Override the key sequence for detaching a container") *
+          Opt("env", "e").help("Set environment variables")[actions::Append()] *
+          Opt("env-file").help("Read in a file of environment variables")[actions::Append()] *
+          Flg("interactive", "i").help("Keep STDIN open even if not attached") *
+          Flg("privileged").help("Give extended privileges to the command") *
+          Flg("tty", "t").help("Allocate a pseudo-TTY") *
+          Opt("user", "u").help("Username or UID (format: <name|uid>[:<group|gid>])") *
+          Opt("workdir", "w").help("Working directory inside the container") *
+          Pos("container").help("Name of the target container") *
+          Pos("command").help("The command to run in the container")[actions::Append().gather()];
 
   constexpr static auto pull = Program("pull").intro("Pull an image or a repository from a registry") +
                                Help() * Pos("name").help("The name of the image or repository to pull") *
@@ -45,23 +46,24 @@ int main(int argc, char const *argv[]) {
           .intro("A self-sufficient runtime for containers")
           .details("Run 'docker COMMAND --help' for more information on a command.") +
       Help() * Version() *
-          Opt("config").help("Location of client config files (default {default_value})").otherwise("~/.docker") *
+          Opt("config").help(
+              "Location of client config files (default {default_value})")[actions::Assign().otherwise("~/.docker")] *
           Opt("context", "c")
               .help("Name of the context to use to connect to the daemon (overrides DOCKER_HOST env var and default "
                     "context set with \"docker context use\")") *
           Flg("debug", "D").help("Enable debug mode") *
-          Opt("host", "H").help("Daemon socket(s) to connect to").append() *
+          Opt("host", "H").help("Daemon socket(s) to connect to")[actions::Append()] *
           Opt("log-level", "l")
               .help("Set the logging level (\"debug\"|\"info\"|\"warn\"|\"error\"|\"fatal\") (default {default_value})")
-              .otherwise("info") *
+                  [actions::Assign().otherwise("info")] *
           Flg("tls").help("Use TLS; implied by --tlsverify") *
           Opt("tlscacert")
-              .help("Trust certs signed only by this CA (default {default_value})")
-              .otherwise("~/.docker/ca.pem") *
-          Opt("tlscert")
-              .help("Path to TLS certificate file (default {default_value})")
-              .otherwise("~/.docker/cert.pem") *
-          Opt("tlskey").help("Path to TLS key file (default {default_value})").otherwise("~/.docker/key.pem") *
+              .help("Trust certs signed only by this CA (default {default_value})")[actions::Assign().otherwise(
+                  "~/.docker/ca.pem")] *
+          Opt("tlscert").help("Path to TLS certificate file (default {default_value})")[actions::Assign().otherwise(
+              "~/.docker/cert.pem")] *
+          Opt("tlskey").help(
+              "Path to TLS key file (default {default_value})")[actions::Assign().otherwise("~/.docker/key.pem")] *
           Flg("tlsverify").help("Use TLS and verify the remote") +
       exec * pull;
 

--- a/examples/docker.cpp
+++ b/examples/docker.cpp
@@ -19,19 +19,18 @@ using vec = std::vector<T>;
 int main(int argc, char const *argv[]) {
   using namespace opzioni;
 
-  constexpr static auto exec =
-      Program("exec").intro("Run a command in a running container") +
-      Help() * Flg("detach", "d").help("Detached mode: run command in the background") *
-          Opt("detach-keys").help("Override the key sequence for detaching a container") *
-          Opt("env", "e").help("Set environment variables")[actions::Append()] *
-          Opt("env-file").help("Read in a file of environment variables")[actions::Append()] *
-          Flg("interactive", "i").help("Keep STDIN open even if not attached") *
-          Flg("privileged").help("Give extended privileges to the command") *
-          Flg("tty", "t").help("Allocate a pseudo-TTY") *
-          Opt("user", "u").help("Username or UID (format: <name|uid>[:<group|gid>])") *
-          Opt("workdir", "w").help("Working directory inside the container") *
-          Pos("container").help("Name of the target container") *
-          Pos("command").help("The command to run in the container")[actions::Append().gather()];
+  constexpr static auto exec = Program("exec").intro("Run a command in a running container") +
+                               Help() * Flg("detach", "d").help("Detached mode: run command in the background") *
+                                   Opt("detach-keys").help("Override the key sequence for detaching a container") *
+                                   Opt("env", "e").help("Set environment variables")[act::Append()] *
+                                   Opt("env-file").help("Read in a file of environment variables")[act::Append()] *
+                                   Flg("interactive", "i").help("Keep STDIN open even if not attached") *
+                                   Flg("privileged").help("Give extended privileges to the command") *
+                                   Flg("tty", "t").help("Allocate a pseudo-TTY") *
+                                   Opt("user", "u").help("Username or UID (format: <name|uid>[:<group|gid>])") *
+                                   Opt("workdir", "w").help("Working directory inside the container") *
+                                   Pos("container").help("Name of the target container") *
+                                   Pos("command").help("The command to run in the container")[act::Append().gather()];
 
   constexpr static auto pull = Program("pull").intro("Pull an image or a repository from a registry") +
                                Help() * Pos("name").help("The name of the image or repository to pull") *
@@ -47,23 +46,23 @@ int main(int argc, char const *argv[]) {
           .details("Run 'docker COMMAND --help' for more information on a command.") +
       Help() * Version() *
           Opt("config").help(
-              "Location of client config files (default {default_value})")[actions::Assign().otherwise("~/.docker")] *
+              "Location of client config files (default {default_value})")[act::Assign().otherwise("~/.docker")] *
           Opt("context", "c")
               .help("Name of the context to use to connect to the daemon (overrides DOCKER_HOST env var and default "
                     "context set with \"docker context use\")") *
           Flg("debug", "D").help("Enable debug mode") *
-          Opt("host", "H").help("Daemon socket(s) to connect to")[actions::Append()] *
+          Opt("host", "H").help("Daemon socket(s) to connect to")[act::Append()] *
           Opt("log-level", "l")
               .help("Set the logging level (\"debug\"|\"info\"|\"warn\"|\"error\"|\"fatal\") (default {default_value})")
-                  [actions::Assign().otherwise("info")] *
+                  [act::Assign().otherwise("info")] *
           Flg("tls").help("Use TLS; implied by --tlsverify") *
           Opt("tlscacert")
-              .help("Trust certs signed only by this CA (default {default_value})")[actions::Assign().otherwise(
+              .help("Trust certs signed only by this CA (default {default_value})")[act::Assign().otherwise(
                   "~/.docker/ca.pem")] *
-          Opt("tlscert").help("Path to TLS certificate file (default {default_value})")[actions::Assign().otherwise(
-              "~/.docker/cert.pem")] *
+          Opt("tlscert").help(
+              "Path to TLS certificate file (default {default_value})")[act::Assign().otherwise("~/.docker/cert.pem")] *
           Opt("tlskey").help(
-              "Path to TLS key file (default {default_value})")[actions::Assign().otherwise("~/.docker/key.pem")] *
+              "Path to TLS key file (default {default_value})")[act::Assign().otherwise("~/.docker/key.pem")] *
           Flg("tlsverify").help("Use TLS and verify the remote") +
       exec * pull;
 

--- a/examples/gather.cpp
+++ b/examples/gather.cpp
@@ -7,26 +7,22 @@
 
 int main(int argc, char const *argv[]) {
   using fmt::print;
-  using opzioni::Help, opzioni::Opt, opzioni::Pos, opzioni::Version;
-  using opzioni::Program, opzioni::ArgValue;
+  using namespace opzioni;
 
   constexpr auto program =
       Program("gather", "A short example file to illustrate the gather feature").version("1.0") +
       Help() * Version() *
-          Pos("all")
-              .help(
-                  "This is the equivalent of Python's argparse `nargs` with `+`: it requires at least one value and "
-                  "consumes all of them into a vector. Note that precisely this type of argument is somewhat limiting "
-                  "because, since it consumes every argument, it will not allow us to parse anything that comes after "
-                  "it")
-              .gather() *
-          Opt("two")
-              .help("This is similar to the previous gather, but it limits the amount of consumed arguments to only "
-                    "{gather_amount}, hence it is not so problematic. Default: {default_value}")
-              .gather<int>(2)
-              .otherwise(+[](ArgValue &arg) {
+          Pos("all").help(
+              "This is the equivalent of Python's argparse `nargs` with `+`: it requires at least one value and "
+              "consumes all of them into a vector. Note that precisely this type of argument is somewhat limiting "
+              "because, since it consumes every argument, it will not allow us to parse anything that comes after "
+              "it")[actions::Append<int>().gather()] *
+          Opt("two").help(
+              "This is similar to the previous gather, but it limits the amount of consumed arguments to only "
+              "{gather_amount}, hence it is not so problematic. Default: {default_value}")
+              [actions::Append<int>().gather(2).otherwise(+[](ArgValue &arg) {
                 arg.value = std::vector{0, 0};
-              });
+              })];
 
   auto const args = program(argc, argv);
   print("\nCommand path: {}\n", args.exec_path);

--- a/examples/gather.cpp
+++ b/examples/gather.cpp
@@ -16,11 +16,11 @@ int main(int argc, char const *argv[]) {
               "This is the equivalent of Python's argparse `nargs` with `+`: it requires at least one value and "
               "consumes all of them into a vector. Note that precisely this type of argument is somewhat limiting "
               "because, since it consumes every argument, it will not allow us to parse anything that comes after "
-              "it")[actions::Append<int>().gather()] *
+              "it")[act::Append<int>().gather()] *
           Opt("two").help(
               "This is similar to the previous gather, but it limits the amount of consumed arguments to only "
               "{gather_amount}, hence it is not so problematic. Default: {default_value}")
-              [actions::Append<int>().gather(2).otherwise(+[](ArgValue &arg) {
+              [act::Append<int>().gather(2).otherwise(+[](ArgValue &arg) {
                 arg.value = std::vector{0, 0};
               })];
 

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -17,30 +17,29 @@ int main(int argc, char const *argv[]) {
           .details("This example only covers simple positionals, options, and flags. For examples of more"
                    " complicated parse actions or subcommands, please take a look at the other examples.") +
       Help() * Version() * Pos("name").help("Your first name") *
-          Opt("double", "d").help("A double. Default: {default_value}")[actions::Assign<double>().otherwise(7.11)] *
+          Opt("double", "d").help("A double. Default: {default_value}")[act::Assign<double>().otherwise(7.11)] *
           Opt("last-name").help("Your last name") *
           Opt("o").help(
-              "We also support having short names only. Default: {default_value}")[actions::Assign().otherwise("oh")] *
+              "We also support having short names only. Default: {default_value}")[act::Assign().otherwise("oh")] *
           Opt("num", "n")
               .help("Creates a vector of numbers with each appearence of this argument. Default: {default_value}")
-                  [actions::Append<int>()] *
+                  [act::Append<int>()] *
           Opt("csv").help("In contrast to `Append`, this will create a vector of numbers from a single "
-                          "comma-separated list of values. Default: {default_value}")[actions::List<int>()] *
+                          "comma-separated list of values. Default: {default_value}")[act::List<int>()] *
           Opt("verbose", "v")
               .help("Level of verbosity. "
                     "Sets to {implicit_value} if given without a value (e.g. -{abbrev}). Default: {default_value}")
-                  [actions::Assign<int>().implicitly(1).otherwise(0)] *
+                  [act::Assign<int>().implicitly(1).otherwise(0)] *
           Flg("append", "a")
               .help("The equivalent of Python's argparse `append_const`: will append {implicit_value} every time it "
-                    "appears in the CLI. Default: {default_value}")[actions::Append<int>().implicitly(1)] *
+                    "appears in the CLI. Default: {default_value}")[act::Append<int>().implicitly(1)] *
           Flg("flag", "f")
               .help(
                   "The equivalent of Python's argparse `store_const`: will store \"{implicit_value}\" if it appears in "
-                  "the CLI. Default: {default_value}")
-                  [actions::Assign().implicitly("do something!").otherwise("nope")] *
+                  "the CLI. Default: {default_value}")[act::Assign().implicitly("do something!").otherwise("nope")] *
           Counter("t").help("We also support flags with only short names. This argument counts how many times it "
                             "appears in the CLI. Default: {default_value}") *
-          Opt("woo", "w").help("Woo")[actions::Append<int>().gather(3)];
+          Opt("woo", "w").help("Woo")[act::Append<int>().gather(3)];
 
   auto const args = program(argc, argv);
   print("\nCommand path: {}\n", args.exec_path);

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -8,8 +8,7 @@
 
 int main(int argc, char const *argv[]) {
   using fmt::print;
-  using opzioni::Help, opzioni::Version;
-  using opzioni::Program, opzioni::Flg, opzioni::Opt, opzioni::Pos;
+  using namespace opzioni;
 
   constexpr auto program =
       Program("main")
@@ -18,32 +17,30 @@ int main(int argc, char const *argv[]) {
           .details("This example only covers simple positionals, options, and flags. For examples of more"
                    " complicated parse actions or subcommands, please take a look at the other examples.") +
       Help() * Version() * Pos("name").help("Your first name") *
-          Opt("double", "d").help("A double. Default: {default_value}").otherwise(7.11) *
+          Opt("double", "d").help("A double. Default: {default_value}")[actions::Assign<double>().otherwise(7.11)] *
           Opt("last-name").help("Your last name") *
-          Opt("o").help("We also support options with only short names. Default: {default_value}").otherwise("oh") *
+          Opt("o").help(
+              "We also support having short names only. Default: {default_value}")[actions::Assign().otherwise("oh")] *
           Opt("num", "n")
-              .append<int>()
-              .help("Creates a vector of numbers with each appearence of this argument. Default: {default_value}") *
-          Opt("csv").csv<int>().help("In contrast to `append`, this will create a vector of numbers from a single "
-                                     "comma-separated list of values. Default: {default_value}") *
+              .help("Creates a vector of numbers with each appearence of this argument. Default: {default_value}")
+                  [actions::Append<int>()] *
+          Opt("csv").help("In contrast to `Append`, this will create a vector of numbers from a single "
+                          "comma-separated list of values. Default: {default_value}")[actions::List<int>()] *
           Opt("verbose", "v")
               .help("Level of verbosity. "
                     "Sets to {implicit_value} if given without a value (e.g. -{abbrev}). Default: {default_value}")
-              .implicitly(1)
-              .otherwise(0) *
+                  [actions::Assign<int>().implicitly(1).otherwise(0)] *
           Flg("append", "a")
-              .implicitly(1)
-              .append<int>()
               .help("The equivalent of Python's argparse `append_const`: will append {implicit_value} every time it "
-                    "appears in the CLI. Default: {default_value}") *
+                    "appears in the CLI. Default: {default_value}")[actions::Append<int>().implicitly(1)] *
           Flg("flag", "f")
-              .implicitly("do something!")
-              .otherwise("nope")
               .help(
                   "The equivalent of Python's argparse `store_const`: will store \"{implicit_value}\" if it appears in "
-                  "the CLI. Default: {default_value}") *
-          Flg("t").count().help("We also support flags with only short names. This argument counts how many times it "
-                                "appears in the CLI. Default: {default_value}");
+                  "the CLI. Default: {default_value}")
+                  [actions::Assign().implicitly("do something!").otherwise("nope")] *
+          Counter("t").help("We also support flags with only short names. This argument counts how many times it "
+                            "appears in the CLI. Default: {default_value}") *
+          Opt("woo", "w").help("Woo")[actions::Append<int>().gather(3)];
 
   auto const args = program(argc, argv);
   print("\nCommand path: {}\n", args.exec_path);
@@ -57,6 +54,7 @@ int main(int argc, char const *argv[]) {
   print("o: {}\n", args.as<std::string_view>("o"));
   print("num: {}\n", args.as<std::vector<int>>("num"));
   print("csv: {}\n", args.as<std::vector<int>>("csv"));
+  print("woo: {}\n", args.as<std::vector<int>>("woo"));
   print("verbose: {}\n", args.as<int>("verbose"));
 
   print("append: {}\n", args.has("append") ? args.as<std::vector<int>>("append") : std::vector<int>{});

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -192,7 +192,7 @@ concept Action = requires(A action) {
 
 namespace actions {
 
-template <concepts::BuiltinType Elem>
+template <concepts::BuiltinType Elem = std::string_view>
 class Append {
 public:
   using value_type = Elem;
@@ -241,7 +241,7 @@ private:
   DefaultValueSetter default_setter = set_empty_vector<Elem>;
 };
 
-template <concepts::BuiltinType Elem>
+template <concepts::BuiltinType Elem = std::string_view>
 class List {
 public:
   using value_type = Elem;

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -197,6 +197,37 @@ concept Action = requires(A action) {
 
 } // namespace concepts
 
+namespace actions {
+
+template <concepts::BuiltinType Elem>
+class Gather {
+public:
+  using value_type = Elem;
+
+  std::size_t amount = 1;
+
+  consteval Gather() = default;
+  consteval Gather(std::size_t amount) : amount(amount) {}
+
+  consteval Gather<Elem> otherwise(DefaultValueSetter setter) const noexcept {
+    auto gather = *this;
+    gather.default_setter = setter;
+    return gather;
+  }
+
+  consteval std::monostate get_default_value() const noexcept { return std::monostate{}; }
+  consteval std::monostate get_implicit_value() const noexcept { return std::monostate{}; }
+  consteval opzioni::actions::Signature get_fn() const noexcept { return this->action_fn; }
+  consteval std::size_t get_gather_amount() const noexcept { return this->amount; }
+  consteval opzioni::DefaultValueSetter get_default_setter() const noexcept { return this->default_setter; }
+
+private:
+  actions::Signature action_fn = actions::append<Elem>;
+  DefaultValueSetter default_setter = set_empty_vector<Elem>;
+};
+
+} // namespace actions
+
 // +-----+
 // | Arg |
 // +-----+

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -203,7 +203,7 @@ public:
     return Append(this->is_required, this->implicit_value, amount, this->default_setter);
   }
 
-  consteval Append<Elem> gather() const noexcept { return gather<Elem>(0); }
+  consteval Append<Elem> gather() const noexcept { return gather(0); }
 
   consteval Append<Elem> implicitly(Elem value) const noexcept {
     return Append(this->is_required, value, this->gather_amount, this->default_setter);

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -345,16 +345,6 @@ struct Arg {
     return arg;
   }
 
-  consteval Arg count() const noexcept {
-    if (this->type != ArgType::FLG)
-      throw "Count arguments must be flags";
-    auto arg = Arg::With(*this, std::monostate{}, std::monostate{});
-    if (!this->is_required)
-      arg = arg.otherwise(std::size_t{0});
-    arg.action_fn = actions::count;
-    return arg;
-  }
-
   template <concepts::BuiltinType Elem = std::string_view>
   consteval Arg csv() const noexcept {
     if (this->type == ArgType::FLG)
@@ -567,6 +557,18 @@ consteval Arg Flg(std::string_view name, std::string_view abbrev) noexcept {
 }
 
 consteval Arg Flg(std::string_view name) noexcept { return Flg(name, {}); }
+
+consteval Arg Counter(std::string_view name, std::string_view abbrev) noexcept {
+  auto const arg = Arg{.type = ArgType::FLG,
+                       .name = name,
+                       .abbrev = abbrev,
+                       .default_value = std::size_t{0},
+                       .action_fn = actions::count};
+  validate_arg(arg);
+  return arg;
+}
+
+consteval Arg Counter(std::string_view name) noexcept { return Counter(name, {}); }
 
 consteval Arg Opt(std::string_view name, std::string_view abbrev) noexcept {
   auto const arg = Arg{.type = ArgType::OPT, .name = name, .abbrev = abbrev, .default_value = ""};

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -263,6 +263,8 @@ public:
     return otherwise(std::string_view(value));
   }
 
+  consteval Assign<Elem> required() const noexcept { return Assign(true, std::nullopt, this->implicit_value); }
+
   consteval bool get_is_required() const noexcept { return this->is_required; }
   consteval std::optional<Elem> get_default_value() const noexcept { return this->default_value; }
   consteval std::optional<Elem> get_implicit_value() const noexcept { return this->implicit_value; }

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -366,97 +366,11 @@ struct Arg {
   std::size_t gather_amount = 1;
   DefaultValueSetter default_setter = nullptr;
 
-  consteval Arg action(actions::Signature action_fn) const noexcept {
-    auto arg = *this;
-    arg.action_fn = action_fn;
-    return arg;
-  }
-
-  template <concepts::BuiltinType Elem = std::string_view>
-  consteval Arg append() const noexcept {
-    auto arg = Arg::With(*this, std::monostate{}, this->implicit_value);
-    arg.action_fn = actions::append<Elem>;
-    if (!this->is_required)
-      arg.default_setter = set_empty_vector<Elem>;
-    return arg;
-  }
-
-  template <concepts::BuiltinType Elem = std::string_view>
-  consteval Arg csv() const noexcept {
-    if (this->type == ArgType::FLG)
-      throw "Flags cannot use the csv action because they do not take values from the command-line";
-    auto arg = Arg::With(*this, std::monostate{}, this->implicit_value);
-    arg.action_fn = actions::csv<Elem>;
-    if (!this->is_required)
-      arg.default_setter = set_empty_vector<Elem>;
-    return arg;
-  }
-
-  template <concepts::BuiltinType Elem = std::string_view>
-  consteval Arg gather(std::size_t amount) const noexcept {
-    if (this->type == ArgType::FLG)
-      throw "Flags cannot use gather because they do not take values from the command-line";
-    auto arg = Arg::With(*this, std::monostate{}, this->implicit_value);
-    arg.gather_amount = amount;
-    arg.action_fn = actions::append<Elem>;
-    if (!this->is_required)
-      arg.default_setter = set_empty_vector<Elem>;
-    return arg;
-  }
-
-  template <concepts::BuiltinType Elem = std::string_view>
-  consteval Arg gather() const noexcept {
-    return gather<Elem>(0);
-  }
-
   consteval Arg help(std::string_view description) const noexcept {
     auto arg = *this;
     arg.description = description;
     return arg;
   }
-
-  template <concepts::BuiltinType T>
-  consteval Arg of() const noexcept {
-    auto arg = *this;
-    arg.action_fn = actions::assign<T>;
-    return arg;
-  }
-
-  template <concepts::BuiltinType T>
-  consteval Arg otherwise(T value) const noexcept {
-    auto arg = Arg::With(*this, value, this->implicit_value);
-    arg.action_fn = actions::assign<T>;
-    arg.default_setter = nullptr;
-    arg.is_required = false;
-    return arg;
-  }
-
-  consteval Arg otherwise(char const *value) const noexcept { return otherwise(std::string_view(value)); }
-
-  consteval Arg otherwise(DefaultValueSetter setter) const noexcept {
-    auto arg = Arg::With(*this, std::monostate{}, this->implicit_value);
-    arg.default_setter = setter;
-    arg.is_required = false;
-    return arg;
-  }
-
-  consteval Arg required() const noexcept {
-    auto arg = Arg::With(*this, std::monostate{}, this->implicit_value);
-    arg.default_setter = nullptr;
-    arg.is_required = true;
-    return arg;
-  }
-
-  template <concepts::BuiltinType T>
-  consteval Arg implicitly(T value) const noexcept {
-    if (this->type == ArgType::POS)
-      throw "Positionals cannot use implicit value because they always take a value from the command-line";
-    auto arg = Arg::With(*this, this->default_value, value);
-    arg.action_fn = actions::assign<T>;
-    return arg;
-  }
-
-  consteval Arg implicitly(char const *value) const noexcept { return implicitly(std::string_view(value)); }
 
   template <concepts::Action Action>
   consteval Arg operator[](Action action) const noexcept {

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -242,6 +242,47 @@ private:
 };
 
 template <concepts::BuiltinType Elem = std::string_view>
+class Assign {
+public:
+  using value_type = Elem;
+
+  consteval Assign() = default;
+
+  consteval Assign<Elem> implicitly(Elem value) const noexcept {
+    return Assign(this->is_required, this->default_value, value);
+  }
+
+  consteval Assign<Elem> implicitly(char const *value) const noexcept requires std::is_same_v<Elem, std::string_view> {
+    return implicitly(std::string_view(value));
+  }
+
+  consteval Assign<Elem> optional() const noexcept {
+    return Assign(false, this->default_value, this-implicit_value);
+  }
+
+  consteval Assign<Elem> otherwise(Elem value) const noexcept { return Assign(false, value, this->implicit_value); }
+
+  consteval Assign<Elem> otherwise(char const *value) const noexcept requires std::is_same_v<Elem, std::string_view> {
+    return otherwise(std::string_view(value));
+  }
+
+  consteval bool get_is_required() const noexcept { return this->is_required; }
+  consteval std::optional<Elem> get_default_value() const noexcept { return this->default_value; }
+  consteval std::optional<Elem> get_implicit_value() const noexcept { return this->implicit_value; }
+  consteval actions::Signature get_fn() const noexcept { return actions::assign<Elem>; }
+  consteval std::size_t get_gather_amount() const noexcept { return 1; }
+  consteval DefaultValueSetter get_default_setter() const noexcept { return nullptr; }
+
+private:
+  bool is_required = true;
+  std::optional<Elem> default_value{};
+  std::optional<Elem> implicit_value{};
+
+  consteval Assign(bool is_required, std::optional<Elem> default_value, std::optional<Elem> implicit_value)
+      : is_required(is_required), default_value(default_value), implicit_value(implicit_value) {}
+};
+
+template <concepts::BuiltinType Elem = std::string_view>
 class List {
 public:
   using value_type = Elem;

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -252,6 +252,27 @@ private:
   DefaultValueSetter default_setter = set_empty_vector<Elem>;
 };
 
+template <concepts::BuiltinType Elem>
+class List {
+public:
+  using value_type = Elem;
+
+  consteval List<Elem> otherwise(DefaultValueSetter setter) const noexcept {
+    auto list = *this;
+    list.default_setter = setter;
+    return list;
+  }
+
+  consteval std::optional<Elem> get_default_value() const noexcept { return std::nullopt; }
+  consteval std::optional<Elem> get_implicit_value() const noexcept { return std::nullopt; }
+  consteval actions::Signature get_fn() const noexcept { return actions::csv<Elem>; }
+  consteval std::size_t get_gather_amount() const noexcept { return 1; }
+  consteval DefaultValueSetter get_default_setter() const noexcept { return this->default_setter; }
+
+private:
+  DefaultValueSetter default_setter = set_empty_vector<Elem>;
+};
+
 } // namespace actions
 
 // +-----+

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -56,33 +56,9 @@ int print_error(ProgramView const, UserError const &) noexcept;
 int print_error_and_usage(ProgramView const, UserError const &) noexcept;
 int rethrow(ProgramView const, UserError const &);
 
-// +---------+
-// | actions |
-// +---------+
-namespace act::fn {
-
-using Signature = void (*)(ProgramView const, ArgMap &, Arg const &, std::optional<std::string_view> const);
-
-template <concepts::BuiltinType T>
-void assign(ProgramView const, ArgMap &, Arg const &, std::optional<std::string_view> const);
-
-template <concepts::BuiltinType Elem>
-void append(ProgramView const, ArgMap &, Arg const &, std::optional<std::string_view> const);
-
-void count(ProgramView const, ArgMap &, Arg const &, std::optional<std::string_view> const);
-
-template <concepts::BuiltinType Elem>
-void csv(ProgramView const, ArgMap &, Arg const &, std::optional<std::string_view> const);
-
-void print_help(ProgramView const, ArgMap &, Arg const &, std::optional<std::string_view> const);
-
-void print_version(ProgramView const, ArgMap &, Arg const &, std::optional<std::string_view> const);
-
-} // namespace act::fn
-
-// +-----------+
-// | arguments |
-// +-----------+
+// +--------------+
+// | argument map |
+// +--------------+
 
 struct ArgValue {
   ExternalVariant value{};
@@ -153,12 +129,41 @@ struct ArgMap {
   std::map<std::string_view, ArgValue> args;
 };
 
+// +-------------------------------+
+// | generic default value setters |
+// +-------------------------------+
+
 using DefaultValueSetter = void (*)(ArgValue &);
 
 template <concepts::BuiltinType T>
 void set_empty_vector(ArgValue &arg) noexcept {
   arg.value = std::vector<T>{};
 }
+
+// +---------+
+// | actions |
+// +---------+
+
+namespace act::fn {
+
+using Signature = void (*)(ProgramView const, ArgMap &, Arg const &, std::optional<std::string_view> const);
+
+template <concepts::BuiltinType T>
+void assign(ProgramView const, ArgMap &, Arg const &, std::optional<std::string_view> const);
+
+template <concepts::BuiltinType Elem>
+void append(ProgramView const, ArgMap &, Arg const &, std::optional<std::string_view> const);
+
+void count(ProgramView const, ArgMap &, Arg const &, std::optional<std::string_view> const);
+
+template <concepts::BuiltinType Elem>
+void csv(ProgramView const, ArgMap &, Arg const &, std::optional<std::string_view> const);
+
+void print_help(ProgramView const, ArgMap &, Arg const &, std::optional<std::string_view> const);
+
+void print_version(ProgramView const, ArgMap &, Arg const &, std::optional<std::string_view> const);
+
+} // namespace act::fn
 
 namespace concepts {
 

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -279,6 +279,18 @@ private:
       : is_required(is_required), default_value(default_value), implicit_value(implicit_value) {}
 };
 
+class Count {
+public:
+  using value_type = std::size_t;
+
+  consteval bool get_is_required() const noexcept { return false; }
+  consteval std::optional<std::size_t> get_default_value() const noexcept { return std::size_t{0}; }
+  consteval std::optional<std::size_t> get_implicit_value() const noexcept { return std::nullopt; }
+  consteval actions::Signature get_fn() const noexcept { return actions::count; }
+  consteval std::size_t get_gather_amount() const noexcept { return 1; }
+  consteval DefaultValueSetter get_default_setter() const noexcept { return nullptr; }
+};
+
 template <concepts::BuiltinType Elem = std::string_view>
 class List {
 public:
@@ -308,6 +320,30 @@ public:
 private:
   bool is_required = false;
   DefaultValueSetter default_setter = set_empty_vector<Elem>;
+};
+
+class PrintHelp {
+public:
+  using value_type = bool;
+
+  consteval bool get_is_required() const noexcept { return false; }
+  consteval std::optional<bool> get_default_value() const noexcept { return false; }
+  consteval std::optional<bool> get_implicit_value() const noexcept { return true; }
+  consteval actions::Signature get_fn() const noexcept { return actions::print_help; }
+  consteval std::size_t get_gather_amount() const noexcept { return 1; }
+  consteval DefaultValueSetter get_default_setter() const noexcept { return nullptr; }
+};
+
+class PrintVersion {
+public:
+  using value_type = bool;
+
+  consteval bool get_is_required() const noexcept { return false; }
+  consteval std::optional<bool> get_default_value() const noexcept { return false; }
+  consteval std::optional<bool> get_implicit_value() const noexcept { return true; }
+  consteval actions::Signature get_fn() const noexcept { return actions::print_version; }
+  consteval std::size_t get_gather_amount() const noexcept { return 1; }
+  consteval DefaultValueSetter get_default_setter() const noexcept { return nullptr; }
 };
 
 } // namespace actions
@@ -559,13 +595,7 @@ consteval Arg Flg(std::string_view name, std::string_view abbrev) noexcept {
 consteval Arg Flg(std::string_view name) noexcept { return Flg(name, {}); }
 
 consteval Arg Counter(std::string_view name, std::string_view abbrev) noexcept {
-  auto const arg = Arg{.type = ArgType::FLG,
-                       .name = name,
-                       .abbrev = abbrev,
-                       .default_value = std::size_t{0},
-                       .action_fn = actions::count};
-  validate_arg(arg);
-  return arg;
+  return Flg(name, abbrev)[actions::Count()];
 }
 
 consteval Arg Counter(std::string_view name) noexcept { return Counter(name, {}); }
@@ -585,13 +615,13 @@ consteval Arg Pos(std::string_view name) noexcept {
 }
 
 consteval Arg Help(std::string_view description) noexcept {
-  return Flg("help", "h").help(description).action(actions::print_help);
+  return Flg("help", "h").help(description)[actions::PrintHelp()];
 }
 
 consteval Arg Help() noexcept { return Help("Display this information"); }
 
 consteval Arg Version(std::string_view description) noexcept {
-  return Flg("version", "V").help(description).action(actions::print_version);
+  return Flg("version", "V").help(description)[actions::PrintVersion()];
 }
 
 consteval Arg Version() noexcept { return Version("Display the software version"); }

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -190,6 +190,43 @@ concept Action = requires(A action) {
 namespace actions {
 
 template <concepts::BuiltinType Elem>
+class Append {
+public:
+  using value_type = Elem;
+
+  consteval Append() = default;
+
+  consteval Append<Elem> gather(std::size_t amount) const noexcept {
+    auto append = *this;
+    append.gather_amount = amount;
+    return append;
+  }
+
+  consteval Append<Elem> implicitly(Elem value) const noexcept {
+    auto append = *this;
+    append.implicit_value = value;
+    return append;
+  }
+
+  consteval Append<Elem> otherwise(DefaultValueSetter setter) const noexcept {
+    auto append = *this;
+    append.default_setter = setter;
+    return append;
+  }
+
+  consteval std::optional<Elem> get_default_value() const noexcept { return std::nullopt; }
+  consteval std::optional<Elem> get_implicit_value() const noexcept { return this->implicit_value; }
+  consteval actions::Signature get_fn() const noexcept { return actions::append<Elem>; }
+  consteval std::size_t get_gather_amount() const noexcept { return this->gather_amount; }
+  consteval DefaultValueSetter get_default_setter() const noexcept { return this->default_setter; }
+
+private:
+  std::optional<Elem> implicit_value{};
+  std::size_t gather_amount = 1;
+  DefaultValueSetter default_setter = set_empty_vector<Elem>;
+};
+
+template <concepts::BuiltinType Elem>
 class Gather {
 public:
   using value_type = Elem;

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -361,7 +361,7 @@ struct Arg {
   std::string_view name{};
   std::string_view abbrev{};
   std::string_view description{};
-  bool is_required = false;
+  bool is_required = true;
   BuiltinVariant default_value{};
   BuiltinVariant implicit_value{};
   act::fn::Signature action_fn = act::fn::assign<std::string_view>;
@@ -501,6 +501,7 @@ consteval Arg Flg(std::string_view name, std::string_view abbrev) noexcept {
   auto const arg = Arg{.type = ArgType::FLG,
                        .name = name,
                        .abbrev = abbrev,
+                       .is_required = false,
                        .default_value = false,
                        .implicit_value = true,
                        .action_fn = act::fn::assign<bool>};
@@ -517,7 +518,7 @@ consteval Arg Counter(std::string_view name, std::string_view abbrev) noexcept {
 consteval Arg Counter(std::string_view name) noexcept { return Counter(name, {}); }
 
 consteval Arg Opt(std::string_view name, std::string_view abbrev) noexcept {
-  auto const arg = Arg{.type = ArgType::OPT, .name = name, .abbrev = abbrev, .default_value = ""};
+  auto const arg = Arg{.type = ArgType::OPT, .name = name, .abbrev = abbrev, .is_required = false, .default_value = ""};
   validate_arg(arg);
   return arg;
 }

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -255,9 +255,7 @@ public:
     return implicitly(std::string_view(value));
   }
 
-  consteval Assign<Elem> optional() const noexcept {
-    return Assign(false, this->default_value, this-implicit_value);
-  }
+  consteval Assign<Elem> optional() const noexcept { return Assign(false, this->default_value, this - implicit_value); }
 
   consteval Assign<Elem> otherwise(Elem value) const noexcept { return Assign(false, value, this->implicit_value); }
 

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -255,7 +255,7 @@ public:
     return implicitly(std::string_view(value));
   }
 
-  consteval Assign<Elem> optional() const noexcept { return Assign(false, this->default_value, this - implicit_value); }
+  consteval Assign<Elem> optional() const noexcept { return Assign(false, this->default_value, this->implicit_value); }
 
   consteval Assign<Elem> otherwise(Elem value) const noexcept { return Assign(false, value, this->implicit_value); }
 

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -229,32 +229,6 @@ private:
 };
 
 template <concepts::BuiltinType Elem>
-class Gather {
-public:
-  using value_type = Elem;
-
-  std::size_t amount = 1;
-
-  consteval Gather() = default;
-  consteval Gather(std::size_t amount) : amount(amount) {}
-
-  consteval Gather<Elem> otherwise(DefaultValueSetter setter) const noexcept {
-    auto gather = *this;
-    gather.default_setter = setter;
-    return gather;
-  }
-
-  consteval std::optional<Elem> get_default_value() const noexcept { return std::nullopt; }
-  consteval std::optional<Elem> get_implicit_value() const noexcept { return std::nullopt; }
-  consteval actions::Signature get_fn() const noexcept { return actions::append<Elem>; }
-  consteval std::size_t get_gather_amount() const noexcept { return this->amount; }
-  consteval DefaultValueSetter get_default_setter() const noexcept { return this->default_setter; }
-
-private:
-  DefaultValueSetter default_setter = set_empty_vector<Elem>;
-};
-
-template <concepts::BuiltinType Elem>
 class List {
 public:
   using value_type = Elem;

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -59,7 +59,7 @@ int rethrow(ProgramView const, UserError const &);
 // +---------+
 // | actions |
 // +---------+
-namespace actions {
+namespace act::fn {
 
 using Signature = void (*)(ProgramView const, ArgMap &, Arg const &, std::optional<std::string_view> const);
 
@@ -78,7 +78,7 @@ void print_help(ProgramView const, ArgMap &, Arg const &, std::optional<std::str
 
 void print_version(ProgramView const, ArgMap &, Arg const &, std::optional<std::string_view> const);
 
-} // namespace actions
+} // namespace act::fn
 
 // +-----------+
 // | arguments |
@@ -180,7 +180,7 @@ concept Action = requires(A action) {
   noexcept->std::same_as<std::optional<typename A::value_type>>;
 
   { action.get_fn() }
-  noexcept->std::same_as<opzioni::actions::Signature>;
+  noexcept->std::same_as<opzioni::act::fn::Signature>;
   { action.get_gather_amount() }
   noexcept->std::same_as<std::size_t>;
 
@@ -190,7 +190,7 @@ concept Action = requires(A action) {
 
 } // namespace concepts
 
-namespace actions {
+namespace act {
 
 template <concepts::BuiltinType Elem = std::string_view>
 class Append {
@@ -224,7 +224,7 @@ public:
   consteval bool get_is_required() const noexcept { return this->is_required; }
   consteval std::optional<Elem> get_default_value() const noexcept { return std::nullopt; }
   consteval std::optional<Elem> get_implicit_value() const noexcept { return this->implicit_value; }
-  consteval actions::Signature get_fn() const noexcept { return actions::append<Elem>; }
+  consteval act::fn::Signature get_fn() const noexcept { return act::fn::append<Elem>; }
   consteval std::size_t get_gather_amount() const noexcept { return this->gather_amount; }
   consteval DefaultValueSetter get_default_setter() const noexcept { return this->default_setter; }
 
@@ -268,7 +268,7 @@ public:
   consteval bool get_is_required() const noexcept { return this->is_required; }
   consteval std::optional<Elem> get_default_value() const noexcept { return this->default_value; }
   consteval std::optional<Elem> get_implicit_value() const noexcept { return this->implicit_value; }
-  consteval actions::Signature get_fn() const noexcept { return actions::assign<Elem>; }
+  consteval act::fn::Signature get_fn() const noexcept { return act::fn::assign<Elem>; }
   consteval std::size_t get_gather_amount() const noexcept { return 1; }
   consteval DefaultValueSetter get_default_setter() const noexcept { return nullptr; }
 
@@ -288,7 +288,7 @@ public:
   consteval bool get_is_required() const noexcept { return false; }
   consteval std::optional<std::size_t> get_default_value() const noexcept { return std::size_t{0}; }
   consteval std::optional<std::size_t> get_implicit_value() const noexcept { return std::nullopt; }
-  consteval actions::Signature get_fn() const noexcept { return actions::count; }
+  consteval act::fn::Signature get_fn() const noexcept { return act::fn::count; }
   consteval std::size_t get_gather_amount() const noexcept { return 1; }
   consteval DefaultValueSetter get_default_setter() const noexcept { return nullptr; }
 };
@@ -315,7 +315,7 @@ public:
   consteval bool get_is_required() const noexcept { return this->is_required; }
   consteval std::optional<Elem> get_default_value() const noexcept { return std::nullopt; }
   consteval std::optional<Elem> get_implicit_value() const noexcept { return std::nullopt; }
-  consteval actions::Signature get_fn() const noexcept { return actions::csv<Elem>; }
+  consteval act::fn::Signature get_fn() const noexcept { return act::fn::csv<Elem>; }
   consteval std::size_t get_gather_amount() const noexcept { return 1; }
   consteval DefaultValueSetter get_default_setter() const noexcept { return this->default_setter; }
 
@@ -331,7 +331,7 @@ public:
   consteval bool get_is_required() const noexcept { return false; }
   consteval std::optional<bool> get_default_value() const noexcept { return false; }
   consteval std::optional<bool> get_implicit_value() const noexcept { return true; }
-  consteval actions::Signature get_fn() const noexcept { return actions::print_help; }
+  consteval act::fn::Signature get_fn() const noexcept { return act::fn::print_help; }
   consteval std::size_t get_gather_amount() const noexcept { return 1; }
   consteval DefaultValueSetter get_default_setter() const noexcept { return nullptr; }
 };
@@ -343,12 +343,12 @@ public:
   consteval bool get_is_required() const noexcept { return false; }
   consteval std::optional<bool> get_default_value() const noexcept { return false; }
   consteval std::optional<bool> get_implicit_value() const noexcept { return true; }
-  consteval actions::Signature get_fn() const noexcept { return actions::print_version; }
+  consteval act::fn::Signature get_fn() const noexcept { return act::fn::print_version; }
   consteval std::size_t get_gather_amount() const noexcept { return 1; }
   consteval DefaultValueSetter get_default_setter() const noexcept { return nullptr; }
 };
 
-} // namespace actions
+} // namespace act
 
 // +-----+
 // | Arg |
@@ -364,7 +364,7 @@ struct Arg {
   bool is_required = false;
   BuiltinVariant default_value{};
   BuiltinVariant implicit_value{};
-  actions::Signature action_fn = actions::assign<std::string_view>;
+  act::fn::Signature action_fn = act::fn::assign<std::string_view>;
   std::size_t gather_amount = 1;
   DefaultValueSetter default_setter = nullptr;
 
@@ -503,7 +503,7 @@ consteval Arg Flg(std::string_view name, std::string_view abbrev) noexcept {
                        .abbrev = abbrev,
                        .default_value = false,
                        .implicit_value = true,
-                       .action_fn = actions::assign<bool>};
+                       .action_fn = act::fn::assign<bool>};
   validate_arg(arg);
   return arg;
 }
@@ -511,7 +511,7 @@ consteval Arg Flg(std::string_view name, std::string_view abbrev) noexcept {
 consteval Arg Flg(std::string_view name) noexcept { return Flg(name, {}); }
 
 consteval Arg Counter(std::string_view name, std::string_view abbrev) noexcept {
-  return Flg(name, abbrev)[actions::Count()];
+  return Flg(name, abbrev)[act::Count()];
 }
 
 consteval Arg Counter(std::string_view name) noexcept { return Counter(name, {}); }
@@ -531,13 +531,13 @@ consteval Arg Pos(std::string_view name) noexcept {
 }
 
 consteval Arg Help(std::string_view description) noexcept {
-  return Flg("help", "h").help(description)[actions::PrintHelp()];
+  return Flg("help", "h").help(description)[act::PrintHelp()];
 }
 
 consteval Arg Help() noexcept { return Help("Display this information"); }
 
 consteval Arg Version(std::string_view description) noexcept {
-  return Flg("version", "V").help(description)[actions::PrintVersion()];
+  return Flg("version", "V").help(description)[act::PrintVersion()];
 }
 
 consteval Arg Version() noexcept { return Version("Display the software version"); }
@@ -790,7 +790,7 @@ private:
 // | implementation of actions |
 // +---------------------------+
 
-namespace actions {
+namespace act::fn {
 
 // +--------+
 // | assign |
@@ -841,7 +841,7 @@ void csv(ProgramView const, ArgMap &map, Arg const &arg, std::optional<std::stri
   assign_to(map, arg.name, convert<std::vector<Elem>>(*parsed_value));
 }
 
-} // namespace actions
+} // namespace act::fn
 
 } // namespace opzioni
 

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -202,6 +202,8 @@ public:
     return append;
   }
 
+  consteval Append<Elem> gather() const noexcept { return gather<Elem>(0); }
+
   consteval Append<Elem> implicitly(Elem value) const noexcept {
     auto append = *this;
     append.implicit_value = value;

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -511,12 +511,6 @@ consteval Arg Flg(std::string_view name, std::string_view abbrev) noexcept {
 
 consteval Arg Flg(std::string_view name) noexcept { return Flg(name, {}); }
 
-consteval Arg Counter(std::string_view name, std::string_view abbrev) noexcept {
-  return Flg(name, abbrev)[act::Count()];
-}
-
-consteval Arg Counter(std::string_view name) noexcept { return Counter(name, {}); }
-
 consteval Arg Opt(std::string_view name, std::string_view abbrev) noexcept {
   auto const arg = Arg{.type = ArgType::OPT, .name = name, .abbrev = abbrev, .is_required = false, .default_value = ""};
   validate_arg(arg);
@@ -530,6 +524,16 @@ consteval Arg Pos(std::string_view name) noexcept {
   validate_arg(arg);
   return arg;
 }
+
+// +--------------------+
+// | argument shortcuts |
+// +--------------------+
+
+consteval Arg Counter(std::string_view name, std::string_view abbrev) noexcept {
+  return Flg(name, abbrev)[act::Count()];
+}
+
+consteval Arg Counter(std::string_view name) noexcept { return Counter(name, {}); }
 
 consteval Arg Help(std::string_view description) noexcept {
   return Flg("help", "h").help(description)[act::PrintHelp()];

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -200,31 +200,25 @@ public:
   consteval Append() = default;
 
   consteval Append<Elem> gather(std::size_t amount) const noexcept {
-    auto append = *this;
-    append.gather_amount = amount;
-    return append;
+    return Append(this->is_required, this->implicit_value, amount, this->default_setter);
   }
 
   consteval Append<Elem> gather() const noexcept { return gather<Elem>(0); }
 
   consteval Append<Elem> implicitly(Elem value) const noexcept {
-    auto append = *this;
-    append.implicit_value = value;
-    return append;
+    return Append(this->is_required, value, this->gather_amount, this->default_setter);
+  }
+
+  consteval Append<Elem> implicitly(char const *value) const noexcept requires std::is_same_v<Elem, std::string_view> {
+    return implicitly(std::string_view(value));
   }
 
   consteval Append<Elem> otherwise(DefaultValueSetter setter) const noexcept {
-    auto append = *this;
-    append.is_required = false;
-    append.default_setter = setter;
-    return append;
+    return Append(false, this->implicit_value, this->gather_amount, setter);
   }
 
   consteval Append<Elem> required() const noexcept {
-    auto append = *this;
-    append.is_required = true;
-    append.default_setter = nullptr;
-    return append;
+    return Append(true, this->implicit_value, this->gather_amount, nullptr);
   }
 
   consteval bool get_is_required() const noexcept { return this->is_required; }
@@ -239,6 +233,11 @@ private:
   std::optional<Elem> implicit_value{};
   std::size_t gather_amount = 1;
   DefaultValueSetter default_setter = set_empty_vector<Elem>;
+
+  consteval Append(bool is_required, std::optional<Elem> implicit_value, std::size_t gather_amount,
+                   DefaultValueSetter default_setter)
+      : is_required(is_required), implicit_value(implicit_value), gather_amount(gather_amount),
+        default_setter(default_setter) {}
 };
 
 template <concepts::BuiltinType Elem = std::string_view>

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
     'opzioni', 'cpp',
     version: '0.48.0',
     license: 'BSL-1.0',
-    default_options: ['cpp_std=c++2a', 'buildtype=debug']
+    default_options: ['cpp_std=c++20', 'buildtype=debug']
 )
 
 # +--------------+

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project(
     'opzioni', 'cpp',
-    version: '0.47.0',
+    version: '0.48.0',
     license: 'BSL-1.0',
     default_options: ['cpp_std=c++2a', 'buildtype=debug']
 )

--- a/src/opzioni.cpp
+++ b/src/opzioni.cpp
@@ -484,7 +484,7 @@ void HelpFormatter::print_details() const noexcept {
 // | implementation of actions |
 // +---------------------------+
 
-namespace actions {
+namespace act::fn {
 
 void count(ProgramView const, ArgMap &map, Arg const &arg, std::optional<std::string_view> const parsed_value) {
   auto [it, inserted] = map.args.try_emplace(arg.name, std::size_t{1});
@@ -502,7 +502,7 @@ void print_version(ProgramView const program, ArgMap &, Arg const &, std::option
   std::exit(0);
 }
 
-} // namespace actions
+} // namespace act::fn
 
 } // namespace opzioni
 

--- a/tests/opzioni.arg.cpp
+++ b/tests/opzioni.arg.cpp
@@ -97,6 +97,40 @@ SCENARIO("default values", "[Arg][defaults]") {
     THEN("default_setter should be nullptr") { REQUIRE(arg.default_setter == nullptr); }
   }
 
+  WHEN("Counter is called with one argument") {
+    constexpr auto arg = Counter("count");
+
+    THEN("type should be FLG") { REQUIRE(arg.type == ArgType::FLG); }
+    THEN("name should be equal to argument") { REQUIRE(arg.name == "count"); }
+    THEN("abbrev should be empty") { REQUIRE(arg.abbrev.empty()); }
+    THEN("description should be empty") { REQUIRE(arg.description.empty()); }
+    THEN("is_required should be false") { REQUIRE(!arg.is_required); }
+    THEN("default_value should be unsigned zero") {
+      REQUIRE(std::get<std::size_t>(arg.default_value) == std::size_t{0});
+    }
+    THEN("implicit_value should be empty") { REQUIRE(std::holds_alternative<std::monostate>(arg.implicit_value)); }
+    THEN("action_fn should be count") { REQUIRE(arg.action_fn == act::fn::count); }
+    THEN("gather_amount should be 1") { REQUIRE(arg.gather_amount == 1); }
+    THEN("default_setter should be nullptr") { REQUIRE(arg.default_setter == nullptr); }
+  }
+
+  WHEN("Counter is called with two arguments") {
+    constexpr auto arg = Counter("count", "c");
+
+    THEN("type should be FLG") { REQUIRE(arg.type == ArgType::FLG); }
+    THEN("name should be equal to first argument") { REQUIRE(arg.name == "count"); }
+    THEN("abbrev should be equal to second argument") { REQUIRE(arg.abbrev == "c"); }
+    THEN("description should be empty") { REQUIRE(arg.description.empty()); }
+    THEN("is_required should be false") { REQUIRE(!arg.is_required); }
+    THEN("default_value should be unsigned zero") {
+      REQUIRE(std::get<std::size_t>(arg.default_value) == std::size_t{0});
+    }
+    THEN("implicit_value should be empty") { REQUIRE(std::holds_alternative<std::monostate>(arg.implicit_value)); }
+    THEN("action_fn should be count") { REQUIRE(arg.action_fn == act::fn::count); }
+    THEN("gather_amount should be 1") { REQUIRE(arg.gather_amount == 1); }
+    THEN("default_setter should be nullptr") { REQUIRE(arg.default_setter == nullptr); }
+  }
+
   WHEN("Help is called with no argument") {
     constexpr auto arg = Help();
 

--- a/tests/opzioni.arg.cpp
+++ b/tests/opzioni.arg.cpp
@@ -17,7 +17,7 @@ SCENARIO("default values", "[Arg][defaults]") {
     THEN("is_required should be false") { REQUIRE(!arg.is_required); }
     THEN("default_value should be empty") { REQUIRE(std::holds_alternative<std::monostate>(arg.default_value)); }
     THEN("implicit_value should be empty") { REQUIRE(std::holds_alternative<std::monostate>(arg.implicit_value)); }
-    THEN("action_fn should be assign<string_view>") { REQUIRE(arg.action_fn == actions::assign<std::string_view>); }
+    THEN("action_fn should be assign<string_view>") { REQUIRE(arg.action_fn == act::fn::assign<std::string_view>); }
     THEN("gather_amount should be 1") { REQUIRE(arg.gather_amount == 1); }
     THEN("default_setter should be nullptr") { REQUIRE(arg.default_setter == nullptr); }
   }
@@ -32,7 +32,7 @@ SCENARIO("default values", "[Arg][defaults]") {
     THEN("is_required should be false") { REQUIRE(!arg.is_required); }
     THEN("default_value should be false") { REQUIRE(std::get<bool>(arg.default_value) == false); }
     THEN("implicit_value should be true") { REQUIRE(std::get<bool>(arg.implicit_value) == true); }
-    THEN("action_fn should be assign<bool>") { REQUIRE(arg.action_fn == actions::assign<bool>); }
+    THEN("action_fn should be assign<bool>") { REQUIRE(arg.action_fn == act::fn::assign<bool>); }
     THEN("gather_amount should be 1") { REQUIRE(arg.gather_amount == 1); }
     THEN("default_setter should be nullptr") { REQUIRE(arg.default_setter == nullptr); }
   }
@@ -47,7 +47,7 @@ SCENARIO("default values", "[Arg][defaults]") {
     THEN("is_required should be false") { REQUIRE(!arg.is_required); }
     THEN("default_value should be false") { REQUIRE(std::get<bool>(arg.default_value) == false); }
     THEN("implicit_value should be true") { REQUIRE(std::get<bool>(arg.implicit_value) == true); }
-    THEN("action_fn should be assign<bool>") { REQUIRE(arg.action_fn == actions::assign<bool>); }
+    THEN("action_fn should be assign<bool>") { REQUIRE(arg.action_fn == act::fn::assign<bool>); }
     THEN("gather_amount should be 1") { REQUIRE(arg.gather_amount == 1); }
     THEN("default_setter should be nullptr") { REQUIRE(arg.default_setter == nullptr); }
   }
@@ -62,7 +62,7 @@ SCENARIO("default values", "[Arg][defaults]") {
     THEN("is_required should be false") { REQUIRE(!arg.is_required); }
     THEN("default_value should be empty string") { REQUIRE(std::get<std::string_view>(arg.default_value) == ""); }
     THEN("implicit_value should be empty") { REQUIRE(std::holds_alternative<std::monostate>(arg.implicit_value)); }
-    THEN("action_fn should be assign<string_view>") { REQUIRE(arg.action_fn == actions::assign<std::string_view>); }
+    THEN("action_fn should be assign<string_view>") { REQUIRE(arg.action_fn == act::fn::assign<std::string_view>); }
     THEN("gather_amount should be 1") { REQUIRE(arg.gather_amount == 1); }
     THEN("default_setter should be nullptr") { REQUIRE(arg.default_setter == nullptr); }
   }
@@ -77,7 +77,7 @@ SCENARIO("default values", "[Arg][defaults]") {
     THEN("is_required should be false") { REQUIRE(!arg.is_required); }
     THEN("default_value should be empty string") { REQUIRE(std::get<std::string_view>(arg.default_value) == ""); }
     THEN("implicit_value should be empty") { REQUIRE(std::holds_alternative<std::monostate>(arg.implicit_value)); }
-    THEN("action_fn should be assign<string_view>") { REQUIRE(arg.action_fn == actions::assign<std::string_view>); }
+    THEN("action_fn should be assign<string_view>") { REQUIRE(arg.action_fn == act::fn::assign<std::string_view>); }
     THEN("gather_amount should be 1") { REQUIRE(arg.gather_amount == 1); }
     THEN("default_setter should be nullptr") { REQUIRE(arg.default_setter == nullptr); }
   }
@@ -92,7 +92,7 @@ SCENARIO("default values", "[Arg][defaults]") {
     THEN("is_required should be true") { REQUIRE(arg.is_required); }
     THEN("default_value should be empty") { REQUIRE(std::holds_alternative<std::monostate>(arg.default_value)); }
     THEN("implicit_value should be empty") { REQUIRE(std::holds_alternative<std::monostate>(arg.implicit_value)); }
-    THEN("action_fn should be assign<string_view>") { REQUIRE(arg.action_fn == actions::assign<std::string_view>); }
+    THEN("action_fn should be assign<string_view>") { REQUIRE(arg.action_fn == act::fn::assign<std::string_view>); }
     THEN("gather_amount should be 1") { REQUIRE(arg.gather_amount == 1); }
     THEN("default_setter should be nullptr") { REQUIRE(arg.default_setter == nullptr); }
   }
@@ -107,7 +107,7 @@ SCENARIO("default values", "[Arg][defaults]") {
     THEN("is_required should be false") { REQUIRE(!arg.is_required); }
     THEN("default_value should be false") { REQUIRE(std::get<bool>(arg.default_value) == false); }
     THEN("implicit_value should be true") { REQUIRE(std::get<bool>(arg.implicit_value) == true); }
-    THEN("action_fn should be print_help") { REQUIRE(arg.action_fn == actions::print_help); }
+    THEN("action_fn should be print_help") { REQUIRE(arg.action_fn == act::fn::print_help); }
     THEN("gather_amount should be 1") { REQUIRE(arg.gather_amount == 1); }
     THEN("default_setter should be nullptr") { REQUIRE(arg.default_setter == nullptr); }
   }
@@ -122,7 +122,7 @@ SCENARIO("default values", "[Arg][defaults]") {
     THEN("is_required should be false") { REQUIRE(!arg.is_required); }
     THEN("default_value should be false") { REQUIRE(std::get<bool>(arg.default_value) == false); }
     THEN("implicit_value should be true") { REQUIRE(std::get<bool>(arg.implicit_value) == true); }
-    THEN("action_fn should be print_help") { REQUIRE(arg.action_fn == actions::print_help); }
+    THEN("action_fn should be print_help") { REQUIRE(arg.action_fn == act::fn::print_help); }
     THEN("gather_amount should be 1") { REQUIRE(arg.gather_amount == 1); }
     THEN("default_setter should be nullptr") { REQUIRE(arg.default_setter == nullptr); }
   }
@@ -137,7 +137,7 @@ SCENARIO("default values", "[Arg][defaults]") {
     THEN("is_required should be false") { REQUIRE(!arg.is_required); }
     THEN("default_value should be false") { REQUIRE(std::get<bool>(arg.default_value) == false); }
     THEN("implicit_value should be true") { REQUIRE(std::get<bool>(arg.implicit_value) == true); }
-    THEN("action_fn should be print_version") { REQUIRE(arg.action_fn == actions::print_version); }
+    THEN("action_fn should be print_version") { REQUIRE(arg.action_fn == act::fn::print_version); }
     THEN("gather_amount should be 1") { REQUIRE(arg.gather_amount == 1); }
     THEN("default_setter should be nullptr") { REQUIRE(arg.default_setter == nullptr); }
   }
@@ -152,7 +152,7 @@ SCENARIO("default values", "[Arg][defaults]") {
     THEN("is_required should be false") { REQUIRE(!arg.is_required); }
     THEN("default_value should be false") { REQUIRE(std::get<bool>(arg.default_value) == false); }
     THEN("implicit_value should be true") { REQUIRE(std::get<bool>(arg.implicit_value) == true); }
-    THEN("action_fn should be print_version") { REQUIRE(arg.action_fn == actions::print_version); }
+    THEN("action_fn should be print_version") { REQUIRE(arg.action_fn == act::fn::print_version); }
     THEN("gather_amount should be 1") { REQUIRE(arg.gather_amount == 1); }
     THEN("default_setter should be nullptr") { REQUIRE(arg.default_setter == nullptr); }
   }

--- a/tests/opzioni.arg.cpp
+++ b/tests/opzioni.arg.cpp
@@ -14,7 +14,7 @@ SCENARIO("default values", "[Arg][defaults]") {
     THEN("name should be empty") { REQUIRE(arg.name.empty()); }
     THEN("abbrev should be empty") { REQUIRE(arg.abbrev.empty()); }
     THEN("description should be empty") { REQUIRE(arg.description.empty()); }
-    THEN("is_required should be false") { REQUIRE(!arg.is_required); }
+    THEN("is_required should be true") { REQUIRE(arg.is_required); }
     THEN("default_value should be empty") { REQUIRE(std::holds_alternative<std::monostate>(arg.default_value)); }
     THEN("implicit_value should be empty") { REQUIRE(std::holds_alternative<std::monostate>(arg.implicit_value)); }
     THEN("action_fn should be assign<string_view>") { REQUIRE(arg.action_fn == act::fn::assign<std::string_view>); }


### PR DESCRIPTION
Summary: changes the way actions are specified for arguments to use `operator []` instead of following the previously-implemented "fluid interface". The problem with the previous interface was that we didn't have many guarantees that the arguments would respect the rules of the action being set, e.g. the same type for default and implicit values. Now there are different classes for each action, which can enforce these rules, and they themselves provide a fluid interface. It is now more code to type to simply specify a default value for an argument, but that was necessary to maintain these guarantees.

Details:

- renamed the `actions` namespace to `act` to make it shorter
- added a new namespace `fn` under `act` to hold the action _functions_
- added a new `Action` concept that describes how an action _class_ should be
- added new action classes for each action we have. These classes are like recipes that provide just the interface that the corresponding action function supports and enforces type consistency
- added an override for `Arg::operator []` which takes an action class and sets the member variables accordingly
- added a new shortcut `Counter` for the count action because it's a common specialization of a flag and applies only to flags
    - added a test for its default values
- updated library version to 0.48.0
- updated `cpp_std` to `c++20` (was `c++2a`)

Problems:

Not related to this PR, but I just found out during its development that the gather functionality cannot enforce that some argument be specified only once. Since it uses the append action, it may be specified as many times as the CLI user wants, which can sometimes not be desired.