### PR TITLE
feat: use overloaded `add` for arguments and commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ int main(int argc, char const *argv[]) {
     Program("hello")
       .version("0.1")
       .intro("Greeting people since the dawn of computing")
+      .add(Pos("name").help("Your name please, so I can greet you"))
       .add(Help())
-      .add(Version())
-      .add(Pos("name").help("Your name please, so I can greet you"));
+      .add(Version());
 
   auto const args = hello(argc, argv);
   std::string_view const name = args["name"];

--- a/README.md
+++ b/README.md
@@ -66,11 +66,12 @@ int main(int argc, char const *argv[]) {
   using namespace opzioni;
 
   constexpr auto hello =
-      Program("hello").version("0.1").intro(
-          "Greeting people since the dawn of computing") +
-        Pos("name").help("Your name please, so I can greet you") *
-        Help() *
-        Version();
+    Program("hello")
+      .version("0.1")
+      .intro("Greeting people since the dawn of computing")
+      .add(Help())
+      .add(Version())
+      .add(Pos("name").help("Your name please, so I can greet you"));
 
   auto const args = hello(argc, argv);
   std::string_view const name = args["name"];

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -69,9 +69,9 @@ int main(int argc, char const *argv[]) {
     Program("hello")
       .version("0.1")
       .intro("Greeting people since the dawn of computing")
+      .add(Pos("name").help("Your name please, so I can greet you"))
       .add(Help())
-      .add(Version())
-      .add(Pos("name").help("Your name please, so I can greet you"));
+      .add(Version());
 
   auto const args = hello(argc, argv);
   std::string_view const name = args["name"];

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -66,11 +66,12 @@ int main(int argc, char const *argv[]) {
   using namespace opzioni;
 
   constexpr auto hello =
-      Program("hello").version("0.1").intro(
-          "Greeting people since the dawn of computing") +
-        Pos("name").help("Your name please, so I can greet you") *
-        Help() *
-        Version();
+    Program("hello")
+      .version("0.1")
+      .intro("Greeting people since the dawn of computing")
+      .add(Help())
+      .add(Version())
+      .add(Pos("name").help("Your name please, so I can greet you"));
 
   auto const args = hello(argc, argv);
   std::string_view const name = args["name"];

--- a/docs/src/user-guide/the-basics.md
+++ b/docs/src/user-guide/the-basics.md
@@ -59,18 +59,15 @@ These defaults are:
 
 Although possible, if the constructor of `Arg` were to be called, the argument type and all these defaults would have to be manually specified, requiring more typing.
 
-Arguments are added to a program via its operator `+`, but first are gathered into an array via their operator `*`.
-These choices relate to operator precedence, since we first need to build the array, then add the array of arguments to the program.
-Building an array is needed so we can verify that all argument names are unique, for example.
-
-Let's add some arguments to our `curl` program:
+Arguments are added to a program via its `add` member function. Let's add some to our `curl` example:
 
 ```cpp
-constexpr auto curl = Program("curl", "transfer a URL") +
-                        Pos("url").help("The URL to transfer") *
-                        Opt("request", "X").help("The HTTP method to use") *
-                        Flg("verbose", "v").help("Make the operation more talkative") *
-                        Help();
+constexpr auto curl =
+  Program("curl", "transfer a URL")
+    .add(Pos("url").help("The URL to transfer"))
+    .add(Opt("request", "X").help("The HTTP method to use"))
+    .add(Flg("verbose", "v").help("Make the operation more talkative"))
+    .add(Help());
 ```
 
 Since we get an `Arg` after calling one of the three argument factories, we can further customize it with its member functions.
@@ -134,22 +131,23 @@ fmt::print("verbose: {}\n", verbose);
 #include "opzioni.hpp"
 
 int main(int argc, char const *argv[]) {
-    using namespace opzioni;
+  using namespace opzioni;
 
-    constexpr auto curl = Program("curl", "transfer a URL") +
-                            Pos("url").help("The URL to transfer") *
-                            Opt("request", "X").help("The HTTP method to use") *
-                            Flg("verbose", "v").help("Make the operation more talkative") *
-                            Help();
+  constexpr auto curl =
+    Program("curl", "transfer a URL")
+      .add(Pos("url").help("The URL to transfer"))
+      .add(Opt("request", "X").help("The HTTP method to use"))
+      .add(Flg("verbose", "v").help("Make the operation more talkative"))
+      .add(Help());
 
-    auto const map = curl(argc, argv);
+  auto const map = curl(argc, argv);
 
-    std::string_view const url = map["url"];
-    std::string_view const request = map["request"];
-    bool const verbose = map["verbose"];
-    fmt::print("url: {}\n", url);
-    fmt::print("request: {}\n", request);
-    fmt::print("verbose: {}\n", verbose);
+  std::string_view const url = map["url"];
+  std::string_view const request = map["request"];
+  bool const verbose = map["verbose"];
+  fmt::print("url: {}\n", url);
+  fmt::print("request: {}\n", request);
+  fmt::print("verbose: {}\n", verbose);
 }
 ```
 

--- a/docs/src/user-guide/the-basics.md
+++ b/docs/src/user-guide/the-basics.md
@@ -58,6 +58,7 @@ These defaults are:
 - flags have `false` as default value
 
 Although possible, if the constructor of `Arg` were to be called, the argument type and all these defaults would have to be manually specified, requiring more typing.
+`Arg` is an aggregate, though, which eases things a bit.
 
 Arguments are added to a program via its `add` member function. Let's add some to our `curl` example:
 
@@ -70,11 +71,11 @@ constexpr auto curl =
     .add(Help());
 ```
 
-Since we get an `Arg` after calling one of the three argument factories, we can further customize it with its member functions.
-The first one we are presented here is `.help()`, which serves the purpose of setting descriptions to arguments.
+Since we get an `Arg` after calling one of the argument factories, we can further customize it with its member functions.
+The first one we used here is `.help()`, which serves the purpose of setting descriptions to arguments.
 These descriptions are what appears in the automatic help text that opzioni generates.
 
-To tell opzioni that automatic help text is desired, we simply call `Help()`.
+To tell opzioni that automatic help text is desired, we simply add a `Help()`.
 Similar to the previous functions, it's just a helper, but this time to create a very common flag, which is to show the program help.
 
 
@@ -209,7 +210,7 @@ The following list contains the rules that opzioni follows when parsing them.
 
     - `pip -h`, where `h` is a flag of `pip`.
 
-    - `tar -vxz`, where `vxz` are three flags of `tar`.
+    - `tar -vxz`, where `v`, `x`, and `z` are three flags of `tar`.
 
     - `g++ -O2` or `g++ -O=2`, where `O` is an option of `g++` and `2` is its value.
 

--- a/docs/src/user-guide/the-basics.md
+++ b/docs/src/user-guide/the-basics.md
@@ -19,7 +19,7 @@ For instance:
 #include "opzioni.hpp"
 
 int main(int argc, char const *argv[]) {
-    using namespace opzioni;
+  using namespace opzioni;
 }
 ```
 
@@ -157,7 +157,7 @@ int main(int argc, char const *argv[]) {
 
 1. Add an `executable` entry for it in `examples/meson.build`, just like the other examples.
 
-    ```py
+    ```
     curl = executable(
         'curl', 'curl.cpp',
         dependencies: [fmt_dep, opzioni_dep]

--- a/examples/docker.cpp
+++ b/examples/docker.cpp
@@ -22,54 +22,57 @@ int main(int argc, char const *argv[]) {
   constexpr static auto exec =
       Program("exec")
           .intro("Run a command in a running container")
-          .add_args(Help() * Flg("detach", "d").help("Detached mode: run command in the background") *
-                    Opt("detach-keys").help("Override the key sequence for detaching a container") *
-                    Opt("env", "e").help("Set environment variables")[act::Append()] *
-                    Opt("env-file").help("Read in a file of environment variables")[act::Append()] *
-                    Flg("interactive", "i").help("Keep STDIN open even if not attached") *
-                    Flg("privileged").help("Give extended privileges to the command") *
-                    Flg("tty", "t").help("Allocate a pseudo-TTY") *
-                    Opt("user", "u").help("Username or UID (format: <name|uid>[:<group|gid>])") *
-                    Opt("workdir", "w").help("Working directory inside the container") *
-                    Pos("container").help("Name of the target container") *
-                    Pos("command").help("The command to run in the container")[act::Append().gather()]);
+          .add(Help())
+          .add(Flg("detach", "d").help("Detached mode: run command in the background"))
+          .add(Opt("detach-keys").help("Override the key sequence for detaching a container"))
+          .add(Opt("env", "e").help("Set environment variables")[act::Append()])
+          .add(Opt("env-file").help("Read in a file of environment variables")[act::Append()])
+          .add(Flg("interactive", "i").help("Keep STDIN open even if not attached"))
+          .add(Flg("privileged").help("Give extended privileges to the command"))
+          .add(Flg("tty", "t").help("Allocate a pseudo-TTY"))
+          .add(Opt("user", "u").help("Username or UID (format: <name|uid>[:<group|gid>])"))
+          .add(Opt("workdir", "w").help("Working directory inside the container"))
+          .add(Pos("container").help("Name of the target container"))
+          .add(Pos("command").help("The command to run in the container")[act::Append().gather()]);
 
   constexpr static auto pull = Program("pull")
                                    .intro("Pull an image or a repository from a registry")
-                                   .add_args(Help() * Pos("name").help("The name of the image or repository to pull") *
-                                             Flg("all-tags", "a").help("Download all tagged images in the repository") *
-                                             Flg("disable-content-trust").help("Skip image verification") *
-                                             Opt("platform").help("Set platform if server is multi-platform capable") *
-                                             Flg("quiet", "q").help("Supress verbose output"));
+                                   .add(Help())
+                                   .add(Pos("name").help("The name of the image or repository to pull"))
+                                   .add(Flg("all-tags", "a").help("Download all tagged images in the repository"))
+                                   .add(Flg("disable-content-trust").help("Skip image verification"))
+                                   .add(Opt("platform").help("Set platform if server is multi-platform capable"))
+                                   .add(Flg("quiet", "q").help("Supress verbose output"));
 
   constexpr auto docker =
       Program("docker")
           .version("20.10.1, build 831ebea")
           .intro("A self-sufficient runtime for containers")
           .details("Run 'docker COMMAND --help' for more information on a command.")
-          .add_args(
-              Help() * Version() *
-              Opt("config").help(
-                  "Location of client config files (default {default_value})")[act::Assign().otherwise("~/.docker")] *
-              Opt("context", "c")
-                  .help(
-                      "Name of the context to use to connect to the daemon (overrides DOCKER_HOST env var and default "
-                      "context set with \"docker context use\")") *
-              Flg("debug", "D").help("Enable debug mode") *
-              Opt("host", "H").help("Daemon socket(s) to connect to")[act::Append()] *
-              Opt("log-level", "l")
-                  .help("Set the logging level (\"debug\"|\"info\"|\"warn\"|\"error\"|\"fatal\") (default "
-                        "{default_value})")[act::Assign().otherwise("info")] *
-              Flg("tls").help("Use TLS; implied by --tlsverify") *
-              Opt("tlscacert")
-                  .help("Trust certs signed only by this CA (default {default_value})")[act::Assign().otherwise(
-                      "~/.docker/ca.pem")] *
-              Opt("tlscert").help("Path to TLS certificate file (default {default_value})")[act::Assign().otherwise(
-                  "~/.docker/cert.pem")] *
-              Opt("tlskey").help(
-                  "Path to TLS key file (default {default_value})")[act::Assign().otherwise("~/.docker/key.pem")] *
-              Flg("tlsverify").help("Use TLS and verify the remote"))
-          .add_cmds(exec * pull);
+          .add(Help())
+          .add(Version())
+          .add(Opt("config").help(
+              "Location of client config files (default {default_value})")[act::Assign().otherwise("~/.docker")])
+          .add(Opt("context", "c")
+                   .help(
+                       "Name of the context to use to connect to the daemon (overrides DOCKER_HOST env var and default "
+                       "context set with \"docker context use\")"))
+          .add(Flg("debug", "D").help("Enable debug mode"))
+          .add(Opt("host", "H").help("Daemon socket(s) to connect to")[act::Append()])
+          .add(Opt("log-level", "l")
+                   .help("Set the logging level (\"debug\"|\"info\"|\"warn\"|\"error\"|\"fatal\") (default "
+                         "{default_value})")[act::Assign().otherwise("info")])
+          .add(Flg("tls").help("Use TLS; implied by --tlsverify"))
+          .add(Opt("tlscacert")
+                   .help("Trust certs signed only by this CA (default {default_value})")[act::Assign().otherwise(
+                       "~/.docker/ca.pem")])
+          .add(Opt("tlscert").help(
+              "Path to TLS certificate file (default {default_value})")[act::Assign().otherwise("~/.docker/cert.pem")])
+          .add(Opt("tlskey").help(
+              "Path to TLS key file (default {default_value})")[act::Assign().otherwise("~/.docker/key.pem")])
+          .add(Flg("tlsverify").help("Use TLS and verify the remote"))
+          .add(exec)
+          .add(pull);
 
   auto const args = docker(argc, argv);
 

--- a/examples/docker.cpp
+++ b/examples/docker.cpp
@@ -68,8 +68,8 @@ int main(int argc, char const *argv[]) {
                   "~/.docker/cert.pem")] *
               Opt("tlskey").help(
                   "Path to TLS key file (default {default_value})")[act::Assign().otherwise("~/.docker/key.pem")] *
-              Flg("tlsverify").help("Use TLS and verify the remote")) +
-      exec * pull;
+              Flg("tlsverify").help("Use TLS and verify the remote"))
+          .add_cmds(exec * pull);
 
   auto const args = docker(argc, argv);
 

--- a/examples/docker.cpp
+++ b/examples/docker.cpp
@@ -19,51 +19,56 @@ using vec = std::vector<T>;
 int main(int argc, char const *argv[]) {
   using namespace opzioni;
 
-  constexpr static auto exec = Program("exec").intro("Run a command in a running container") +
-                               Help() * Flg("detach", "d").help("Detached mode: run command in the background") *
-                                   Opt("detach-keys").help("Override the key sequence for detaching a container") *
-                                   Opt("env", "e").help("Set environment variables")[act::Append()] *
-                                   Opt("env-file").help("Read in a file of environment variables")[act::Append()] *
-                                   Flg("interactive", "i").help("Keep STDIN open even if not attached") *
-                                   Flg("privileged").help("Give extended privileges to the command") *
-                                   Flg("tty", "t").help("Allocate a pseudo-TTY") *
-                                   Opt("user", "u").help("Username or UID (format: <name|uid>[:<group|gid>])") *
-                                   Opt("workdir", "w").help("Working directory inside the container") *
-                                   Pos("container").help("Name of the target container") *
-                                   Pos("command").help("The command to run in the container")[act::Append().gather()];
+  constexpr static auto exec =
+      Program("exec")
+          .intro("Run a command in a running container")
+          .add_args(Help() * Flg("detach", "d").help("Detached mode: run command in the background") *
+                    Opt("detach-keys").help("Override the key sequence for detaching a container") *
+                    Opt("env", "e").help("Set environment variables")[act::Append()] *
+                    Opt("env-file").help("Read in a file of environment variables")[act::Append()] *
+                    Flg("interactive", "i").help("Keep STDIN open even if not attached") *
+                    Flg("privileged").help("Give extended privileges to the command") *
+                    Flg("tty", "t").help("Allocate a pseudo-TTY") *
+                    Opt("user", "u").help("Username or UID (format: <name|uid>[:<group|gid>])") *
+                    Opt("workdir", "w").help("Working directory inside the container") *
+                    Pos("container").help("Name of the target container") *
+                    Pos("command").help("The command to run in the container")[act::Append().gather()]);
 
-  constexpr static auto pull = Program("pull").intro("Pull an image or a repository from a registry") +
-                               Help() * Pos("name").help("The name of the image or repository to pull") *
-                                   Flg("all-tags", "a").help("Download all tagged images in the repository") *
-                                   Flg("disable-content-trust").help("Skip image verification") *
-                                   Opt("platform").help("Set platform if server is multi-platform capable") *
-                                   Flg("quiet", "q").help("Supress verbose output");
+  constexpr static auto pull = Program("pull")
+                                   .intro("Pull an image or a repository from a registry")
+                                   .add_args(Help() * Pos("name").help("The name of the image or repository to pull") *
+                                             Flg("all-tags", "a").help("Download all tagged images in the repository") *
+                                             Flg("disable-content-trust").help("Skip image verification") *
+                                             Opt("platform").help("Set platform if server is multi-platform capable") *
+                                             Flg("quiet", "q").help("Supress verbose output"));
 
   constexpr auto docker =
       Program("docker")
           .version("20.10.1, build 831ebea")
           .intro("A self-sufficient runtime for containers")
-          .details("Run 'docker COMMAND --help' for more information on a command.") +
-      Help() * Version() *
-          Opt("config").help(
-              "Location of client config files (default {default_value})")[act::Assign().otherwise("~/.docker")] *
-          Opt("context", "c")
-              .help("Name of the context to use to connect to the daemon (overrides DOCKER_HOST env var and default "
-                    "context set with \"docker context use\")") *
-          Flg("debug", "D").help("Enable debug mode") *
-          Opt("host", "H").help("Daemon socket(s) to connect to")[act::Append()] *
-          Opt("log-level", "l")
-              .help("Set the logging level (\"debug\"|\"info\"|\"warn\"|\"error\"|\"fatal\") (default {default_value})")
-                  [act::Assign().otherwise("info")] *
-          Flg("tls").help("Use TLS; implied by --tlsverify") *
-          Opt("tlscacert")
-              .help("Trust certs signed only by this CA (default {default_value})")[act::Assign().otherwise(
-                  "~/.docker/ca.pem")] *
-          Opt("tlscert").help(
-              "Path to TLS certificate file (default {default_value})")[act::Assign().otherwise("~/.docker/cert.pem")] *
-          Opt("tlskey").help(
-              "Path to TLS key file (default {default_value})")[act::Assign().otherwise("~/.docker/key.pem")] *
-          Flg("tlsverify").help("Use TLS and verify the remote") +
+          .details("Run 'docker COMMAND --help' for more information on a command.")
+          .add_args(
+              Help() * Version() *
+              Opt("config").help(
+                  "Location of client config files (default {default_value})")[act::Assign().otherwise("~/.docker")] *
+              Opt("context", "c")
+                  .help(
+                      "Name of the context to use to connect to the daemon (overrides DOCKER_HOST env var and default "
+                      "context set with \"docker context use\")") *
+              Flg("debug", "D").help("Enable debug mode") *
+              Opt("host", "H").help("Daemon socket(s) to connect to")[act::Append()] *
+              Opt("log-level", "l")
+                  .help("Set the logging level (\"debug\"|\"info\"|\"warn\"|\"error\"|\"fatal\") (default "
+                        "{default_value})")[act::Assign().otherwise("info")] *
+              Flg("tls").help("Use TLS; implied by --tlsverify") *
+              Opt("tlscacert")
+                  .help("Trust certs signed only by this CA (default {default_value})")[act::Assign().otherwise(
+                      "~/.docker/ca.pem")] *
+              Opt("tlscert").help("Path to TLS certificate file (default {default_value})")[act::Assign().otherwise(
+                  "~/.docker/cert.pem")] *
+              Opt("tlskey").help(
+                  "Path to TLS key file (default {default_value})")[act::Assign().otherwise("~/.docker/key.pem")] *
+              Flg("tlsverify").help("Use TLS and verify the remote")) +
       exec * pull;
 
   auto const args = docker(argc, argv);

--- a/examples/gather.cpp
+++ b/examples/gather.cpp
@@ -10,19 +10,21 @@ int main(int argc, char const *argv[]) {
   using namespace opzioni;
 
   constexpr auto program =
-      Program("gather", "A short example file to illustrate the gather feature").version("1.0") +
-      Help() * Version() *
-          Pos("all").help(
-              "This is the equivalent of Python's argparse `nargs` with `+`: it requires at least one value and "
-              "consumes all of them into a vector. Note that precisely this type of argument is somewhat limiting "
-              "because, since it consumes every argument, it will not allow us to parse anything that comes after "
-              "it")[act::Append<int>().gather()] *
-          Opt("two").help(
-              "This is similar to the previous gather, but it limits the amount of consumed arguments to only "
-              "{gather_amount}, hence it is not so problematic. Default: {default_value}")
-              [act::Append<int>().gather(2).otherwise(+[](ArgValue &arg) {
-                arg.value = std::vector{0, 0};
-              })];
+      Program("gather", "A short example file to illustrate the gather feature")
+          .version("1.0")
+          .add_args(
+              Help() * Version() *
+              Pos("all").help(
+                  "This is the equivalent of Python's argparse `nargs` with `+`: it requires at least one value and "
+                  "consumes all of them into a vector. Note that precisely this type of argument is somewhat limiting "
+                  "because, since it consumes every argument, it will not allow us to parse anything that comes after "
+                  "it")[act::Append<int>().gather()] *
+              Opt("two").help(
+                  "This is similar to the previous gather, but it limits the amount of consumed arguments to only "
+                  "{gather_amount}, hence it is not so problematic. Default: {default_value}")
+                  [act::Append<int>().gather(2).otherwise(+[](ArgValue &arg) {
+                    arg.value = std::vector{0, 0};
+                  })]);
 
   auto const args = program(argc, argv);
   print("\nCommand path: {}\n", args.exec_path);

--- a/examples/gather.cpp
+++ b/examples/gather.cpp
@@ -12,19 +12,19 @@ int main(int argc, char const *argv[]) {
   constexpr auto program =
       Program("gather", "A short example file to illustrate the gather feature")
           .version("1.0")
-          .add_args(
-              Help() * Version() *
-              Pos("all").help(
-                  "This is the equivalent of Python's argparse `nargs` with `+`: it requires at least one value and "
-                  "consumes all of them into a vector. Note that precisely this type of argument is somewhat limiting "
-                  "because, since it consumes every argument, it will not allow us to parse anything that comes after "
-                  "it")[act::Append<int>().gather()] *
-              Opt("two").help(
-                  "This is similar to the previous gather, but it limits the amount of consumed arguments to only "
-                  "{gather_amount}, hence it is not so problematic. Default: {default_value}")
-                  [act::Append<int>().gather(2).otherwise(+[](ArgValue &arg) {
-                    arg.value = std::vector{0, 0};
-                  })]);
+          .add(Help())
+          .add(Version())
+          .add(Pos("all").help(
+              "This is the equivalent of Python's argparse `nargs` with `+`: it requires at least one value and "
+              "consumes all of them into a vector. Note that precisely this type of argument is somewhat limiting "
+              "because, since it consumes every argument, it will not allow us to parse anything that comes after "
+              "it")[act::Append<int>().gather()])
+          .add(Opt("two").help(
+              "This is similar to the previous gather, but it limits the amount of consumed arguments to only "
+              "{gather_amount}, hence it is not so problematic. Default: {default_value}")
+                   [act::Append<int>().gather(2).otherwise(+[](ArgValue &arg) {
+                     arg.value = std::vector{0, 0};
+                   })]);
 
   auto const args = program(argc, argv);
   print("\nCommand path: {}\n", args.exec_path);

--- a/examples/hello.cpp
+++ b/examples/hello.cpp
@@ -6,8 +6,10 @@
 int main(int argc, char const *argv[]) {
   using namespace opzioni;
 
-  constexpr auto hello = Program("hello").version("0.1").intro("Greeting people since the dawn of computing") +
-                         Help() * Version() * Pos("name").help("Your name please, so I can greet you");
+  constexpr auto hello = Program("hello")
+                             .version("0.1")
+                             .intro("Greeting people since the dawn of computing")
+                             .add_args(Help() * Version() * Pos("name").help("Your name please, so I can greet you"));
 
   auto const args = hello(argc, argv);
   std::string_view const name = args["name"];

--- a/examples/hello.cpp
+++ b/examples/hello.cpp
@@ -9,7 +9,9 @@ int main(int argc, char const *argv[]) {
   constexpr auto hello = Program("hello")
                              .version("0.1")
                              .intro("Greeting people since the dawn of computing")
-                             .add_args(Help() * Version() * Pos("name").help("Your name please, so I can greet you"));
+                             .add(Help())
+                             .add(Version())
+                             .add(Pos("name").help("Your name please, so I can greet you"));
 
   auto const args = hello(argc, argv);
   std::string_view const name = args["name"];

--- a/examples/hello.cpp
+++ b/examples/hello.cpp
@@ -9,9 +9,9 @@ int main(int argc, char const *argv[]) {
   constexpr auto hello = Program("hello")
                              .version("0.1")
                              .intro("Greeting people since the dawn of computing")
+                             .add(Pos("name").help("Your name please, so I can greet you"))
                              .add(Help())
-                             .add(Version())
-                             .add(Pos("name").help("Your name please, so I can greet you"));
+                             .add(Version());
 
   auto const args = hello(argc, argv);
   std::string_view const name = args["name"];

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -15,31 +15,34 @@ int main(int argc, char const *argv[]) {
           .version("1.0")
           .intro("A short example illustrating opzioni's simpler features")
           .details("This example only covers simple positionals, options, and flags. For examples of more"
-                   " complicated parse actions or subcommands, please take a look at the other examples.") +
-      Help() * Version() * Pos("name").help("Your first name") *
-          Opt("double", "d").help("A double. Default: {default_value}")[act::Assign<double>().otherwise(7.11)] *
-          Opt("last-name").help("Your last name") *
-          Opt("o").help(
-              "We also support having short names only. Default: {default_value}")[act::Assign().otherwise("oh")] *
-          Opt("num", "n")
-              .help("Creates a vector of numbers with each appearence of this argument. Default: {default_value}")
-                  [act::Append<int>()] *
-          Opt("csv").help("In contrast to `Append`, this will create a vector of numbers from a single "
-                          "comma-separated list of values. Default: {default_value}")[act::List<int>()] *
-          Opt("verbose", "v")
-              .help("Level of verbosity. "
-                    "Sets to {implicit_value} if given without a value (e.g. -{abbrev}). Default: {default_value}")
-                  [act::Assign<int>().implicitly(1).otherwise(0)] *
-          Flg("append", "a")
-              .help("The equivalent of Python's argparse `append_const`: will append {implicit_value} every time it "
-                    "appears in the CLI. Default: {default_value}")[act::Append<int>().implicitly(1)] *
-          Flg("flag", "f")
-              .help(
-                  "The equivalent of Python's argparse `store_const`: will store \"{implicit_value}\" if it appears in "
-                  "the CLI. Default: {default_value}")[act::Assign().implicitly("do something!").otherwise("nope")] *
-          Counter("t").help("We also support flags with only short names. This argument counts how many times it "
-                            "appears in the CLI. Default: {default_value}") *
-          Opt("woo", "w").help("Woo")[act::Append<int>().gather(3)];
+                   " complicated parse actions or subcommands, please take a look at the other examples.")
+          .add_args(
+              Help() * Version() * Pos("name").help("Your first name") *
+              Opt("double", "d").help("A double. Default: {default_value}")[act::Assign<double>().otherwise(7.11)] *
+              Opt("last-name").help("Your last name") *
+              Opt("o").help(
+                  "We also support having short names only. Default: {default_value}")[act::Assign().otherwise("oh")] *
+              Opt("num", "n")
+                  .help("Creates a vector of numbers with each appearence of this argument. Default: {default_value}")
+                      [act::Append<int>()] *
+              Opt("csv").help("In contrast to `Append`, this will create a vector of numbers from a single "
+                              "comma-separated list of values. Default: {default_value}")[act::List<int>()] *
+              Opt("verbose", "v")
+                  .help("Level of verbosity. "
+                        "Sets to {implicit_value} if given without a value (e.g. -{abbrev}). Default: {default_value}")
+                      [act::Assign<int>().implicitly(1).otherwise(0)] *
+              Flg("append", "a")
+                  .help(
+                      "The equivalent of Python's argparse `append_const`: will append {implicit_value} every time it "
+                      "appears in the CLI. Default: {default_value}")[act::Append<int>().implicitly(1)] *
+              Flg("flag", "f")
+                  .help("The equivalent of Python's argparse `store_const`: will store \"{implicit_value}\" if it "
+                        "appears in "
+                        "the CLI. Default: {default_value}")
+                      [act::Assign().implicitly("do something!").otherwise("nope")] *
+              Counter("t").help("We also support flags with only short names. This argument counts how many times it "
+                                "appears in the CLI. Default: {default_value}") *
+              Opt("woo", "w").help("Woo")[act::Append<int>().gather(3)]);
 
   auto const args = program(argc, argv);
   print("\nCommand path: {}\n", args.exec_path);

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -16,33 +16,33 @@ int main(int argc, char const *argv[]) {
           .intro("A short example illustrating opzioni's simpler features")
           .details("This example only covers simple positionals, options, and flags. For examples of more"
                    " complicated parse actions or subcommands, please take a look at the other examples.")
-          .add_args(
-              Help() * Version() * Pos("name").help("Your first name") *
-              Opt("double", "d").help("A double. Default: {default_value}")[act::Assign<double>().otherwise(7.11)] *
-              Opt("last-name").help("Your last name") *
-              Opt("o").help(
-                  "We also support having short names only. Default: {default_value}")[act::Assign().otherwise("oh")] *
-              Opt("num", "n")
-                  .help("Creates a vector of numbers with each appearence of this argument. Default: {default_value}")
-                      [act::Append<int>()] *
-              Opt("csv").help("In contrast to `Append`, this will create a vector of numbers from a single "
-                              "comma-separated list of values. Default: {default_value}")[act::List<int>()] *
-              Opt("verbose", "v")
-                  .help("Level of verbosity. "
-                        "Sets to {implicit_value} if given without a value (e.g. -{abbrev}). Default: {default_value}")
-                      [act::Assign<int>().implicitly(1).otherwise(0)] *
-              Flg("append", "a")
-                  .help(
-                      "The equivalent of Python's argparse `append_const`: will append {implicit_value} every time it "
-                      "appears in the CLI. Default: {default_value}")[act::Append<int>().implicitly(1)] *
-              Flg("flag", "f")
-                  .help("The equivalent of Python's argparse `store_const`: will store \"{implicit_value}\" if it "
-                        "appears in "
-                        "the CLI. Default: {default_value}")
-                      [act::Assign().implicitly("do something!").otherwise("nope")] *
-              Counter("t").help("We also support flags with only short names. This argument counts how many times it "
-                                "appears in the CLI. Default: {default_value}") *
-              Opt("woo", "w").help("Woo")[act::Append<int>().gather(3)]);
+          .add(Help())
+          .add(Version())
+          .add(Pos("name").help("Your first name"))
+          .add(Opt("double", "d").help("A double. Default: {default_value}")[act::Assign<double>().otherwise(7.11)])
+          .add(Opt("last-name").help("Your last name"))
+          .add(Opt("o").help(
+              "We also support having short names only. Default: {default_value}")[act::Assign().otherwise("oh")])
+          .add(Opt("num", "n")
+                   .help("Creates a vector of numbers with each appearence of this argument. Default: {default_value}")
+                       [act::Append<int>()])
+          .add(Opt("csv").help("In contrast to `Append`, this will create a vector of numbers from a single "
+                               "comma-separated list of values. Default: {default_value}")[act::List<int>()])
+          .add(Opt("verbose", "v")
+                   .help("Level of verbosity. "
+                         "Sets to {implicit_value} if given without a value (e.g. -{abbrev}). Default: {default_value}")
+                       [act::Assign<int>().implicitly(1).otherwise(0)])
+          .add(Flg("append", "a")
+                   .help(
+                       "The equivalent of Python's argparse `append_const`: will append {implicit_value} every time it "
+                       "appears in the CLI. Default: {default_value}")[act::Append<int>().implicitly(1)])
+          .add(Flg("flag", "f")
+                   .help("The equivalent of Python's argparse `store_const`: will store \"{implicit_value}\" if it "
+                         "appears in the CLI. Default: {default_value}")
+                       [act::Assign().implicitly("do something!").otherwise("nope")])
+          .add(Counter("t").help("We also support flags with only short names. This argument counts how many times it "
+                                 "appears in the CLI. Default: {default_value}"))
+          .add(Opt("woo", "w").help("Woo")[act::Append<int>().gather(3)]);
 
   auto const args = program(argc, argv);
   print("\nCommand path: {}\n", args.exec_path);

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -383,11 +383,10 @@ struct Arg {
   consteval Arg operator[](Action action) const noexcept {
     auto const &default_value = action.get_default_value();
     auto const &implicit_value = action.get_implicit_value();
-    auto arg = default_value && implicit_value
-                   ? Arg::With(*this, *default_value, *implicit_value)
-                   : default_value ? Arg::With(*this, *default_value, std::monostate{})
-                                   : implicit_value ? Arg::With(*this, std::monostate{}, *implicit_value)
-                                                    : Arg::With(*this, std::monostate{}, std::monostate{});
+    auto arg = default_value && implicit_value ? Arg::With(*this, *default_value, *implicit_value)
+               : default_value                 ? Arg::With(*this, *default_value, std::monostate{})
+               : implicit_value                ? Arg::With(*this, std::monostate{}, *implicit_value)
+                                               : Arg::With(*this, std::monostate{}, std::monostate{});
     arg.is_required = action.get_is_required();
     arg.action_fn = action.get_fn();
     arg.gather_amount = action.get_gather_amount();

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -383,10 +383,11 @@ struct Arg {
   consteval Arg operator[](Action action) const noexcept {
     auto const &default_value = action.get_default_value();
     auto const &implicit_value = action.get_implicit_value();
-    auto arg = default_value && implicit_value ? Arg::With(*this, *default_value, *implicit_value)
-               : default_value                 ? Arg::With(*this, *default_value, std::monostate{})
-               : implicit_value                ? Arg::With(*this, std::monostate{}, *implicit_value)
-                                               : Arg::With(*this, std::monostate{}, std::monostate{});
+    auto arg = default_value && implicit_value
+                   ? Arg::With(*this, *default_value, *implicit_value)
+                   : default_value ? Arg::With(*this, *default_value, std::monostate{})
+                                   : implicit_value ? Arg::With(*this, std::monostate{}, *implicit_value)
+                                                    : Arg::With(*this, std::monostate{}, std::monostate{});
     arg.is_required = action.get_is_required();
     arg.action_fn = action.get_fn();
     arg.gather_amount = action.get_gather_amount();
@@ -710,7 +711,7 @@ public:
   }
 
   template <std::size_t N>
-  consteval Program<N, CmdsSize> operator+(std::array<Arg, N> args) const noexcept {
+  consteval Program<N, CmdsSize> add_args(std::array<Arg, N> args) const noexcept {
     Program<N, CmdsSize> newprogram(*this);
     std::array<Arg, N> positionals, others;
 

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -429,7 +429,18 @@ struct Arg {
   }
 };
 
-constexpr bool operator<(Arg const &lhs, Arg const &rhs) noexcept { return lhs.name < rhs.name; }
+constexpr bool operator<(Arg const &lhs, Arg const &rhs) noexcept {
+  bool const lhs_is_positional = lhs.type == ArgType::POS;
+  bool const rhs_is_positional = rhs.type == ArgType::POS;
+
+  if (lhs_is_positional && rhs_is_positional)
+    return false; // don't move positionals relative to each other
+
+  if (!lhs_is_positional && !rhs_is_positional)
+    return lhs.name < rhs.name; // sort non-positionals by name
+
+  return lhs_is_positional; // sort positionals before other types
+}
 
 constexpr bool operator==(Arg const &lhs, Arg const &rhs) noexcept {
   auto const same_name = lhs.name == rhs.name;

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -728,7 +728,7 @@ public:
   }
 
   template <std::size_t N>
-  consteval Program<ArgsSize, N> operator+(std::array<ProgramView, N> cmds) const noexcept {
+  consteval Program<ArgsSize, N> add_cmds(std::array<ProgramView, N> cmds) const noexcept {
     Program<ArgsSize, N> newprogram(*this);
     std::ranges::copy(cmds, newprogram.cmds.begin());
     std::sort(newprogram.cmds.begin(), newprogram.cmds.end()); // don't know why can't use std::ranges::sort

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project(
     'opzioni', 'cpp',
-    version: '0.48.0',
+    version: '0.49.0',
     license: 'BSL-1.0',
     default_options: ['cpp_std=c++20', 'buildtype=debug']
 )

--- a/tests/opzioni.arg.cpp
+++ b/tests/opzioni.arg.cpp
@@ -5,7 +5,6 @@
 
 #include "opzioni.hpp"
 
-
 SCENARIO("type traits", "[Arg]") {
   using namespace opzioni;
 

--- a/tests/opzioni.arg.cpp
+++ b/tests/opzioni.arg.cpp
@@ -1,8 +1,16 @@
+#include <type_traits>
 #include <variant>
 
 #include <catch2/catch.hpp>
 
 #include "opzioni.hpp"
+
+
+SCENARIO("type traits", "[Arg]") {
+  using namespace opzioni;
+
+  REQUIRE(std::is_aggregate_v<Arg>);
+}
 
 SCENARIO("default values", "[Arg][defaults]") {
   using namespace opzioni;

--- a/tests/opzioni.program.cpp
+++ b/tests/opzioni.program.cpp
@@ -171,7 +171,7 @@ SCENARIO("adding arguments", "[Program][args]") {
   GIVEN("an empty Program") {
 
     WHEN("a positional is added") {
-      constexpr auto program = Program("program").add_args(std::array{Pos("pos")});
+      constexpr auto program = Program("program").add(Pos("pos"));
 
       THEN("the size of args should match the number of arguments added") { REQUIRE(program.args.size() == 1); }
       THEN("cmds should not be changed") { REQUIRE(program.cmds.size() == 0); }
@@ -182,7 +182,7 @@ SCENARIO("adding arguments", "[Program][args]") {
     }
 
     WHEN("two positionals are added") {
-      constexpr auto program = Program("program").add_args(Pos("pos1") * Pos("pos2"));
+      constexpr auto program = Program("program").add(Pos("pos1")).add(Pos("pos2"));
 
       THEN("the size of args should match the number of arguments added") { REQUIRE(program.args.size() == 2); }
       THEN("cmds should not be changed") { REQUIRE(program.cmds.size() == 0); }
@@ -197,7 +197,7 @@ SCENARIO("adding arguments", "[Program][args]") {
 
     WHEN("multiple positionals are added") {
       constexpr auto program =
-          Program("program").add_args(Pos("pos5") * Pos("pos2") * Pos("pos4") * Pos("pos1") * Pos("pos3"));
+          Program("program").add(Pos("pos5")).add(Pos("pos2")).add(Pos("pos4")).add(Pos("pos1")).add(Pos("pos3"));
 
       THEN("the size of args should match the number of arguments added") { REQUIRE(program.args.size() == 5); }
       THEN("cmds should not be changed") { REQUIRE(program.cmds.size() == 0); }
@@ -214,8 +214,14 @@ SCENARIO("adding arguments", "[Program][args]") {
     }
 
     WHEN("other arguments are added before positionals") {
-      constexpr auto program = Program("program").add_args(Flg("flg1") * Opt("opt2") * Pos("pos3") * Pos("pos1") *
-                                                           Pos("pos2") * Opt("opt1") * Flg("flg2"));
+      constexpr auto program = Program("program")
+                                   .add(Flg("flg1"))
+                                   .add(Opt("opt2"))
+                                   .add(Pos("pos3"))
+                                   .add(Pos("pos1"))
+                                   .add(Pos("pos2"))
+                                   .add(Opt("opt1"))
+                                   .add(Flg("flg2"));
 
       THEN("the size of args should match the number of arguments added") { REQUIRE(program.args.size() == 7); }
       THEN("cmds should not be changed") { REQUIRE(program.cmds.size() == 0); }
@@ -255,7 +261,7 @@ SCENARIO("adding commands", "[Program][cmds]") {
     }
 
     WHEN("cmd is added as command of program") {
-      constexpr auto program = Program("program").add_cmds(std::array{ProgramView(cmd)});
+      constexpr auto program = Program("program").add(cmd);
 
       THEN("cmd should be added as only command of program") {
         REQUIRE(program.cmds.size() == 1);
@@ -284,7 +290,7 @@ SCENARIO("adding commands", "[Program][cmds]") {
     }
 
     WHEN("both cmds are added as commands of program, but cmd2 first") {
-      constexpr auto program = Program("program").add_cmds(cmd2 * cmd1);
+      constexpr auto program = Program("program").add(cmd2).add(cmd1);
 
       THEN("cmd1 should be added as first command of program and cmd2 as second") {
         REQUIRE(program.cmds.size() == 2);
@@ -419,13 +425,19 @@ SCENARIO("parsing", "[Program][parsing]") {
 
   GIVEN("a program with all kinds of arguments and a command") {
     constexpr static auto cmd =
-        Program("cmd").on_error(rethrow).add_args(Flg("f") * Pos("pos1") * Pos("cmd-pos") * Opt("long", "l"));
+        Program("cmd").on_error(rethrow).add(Flg("f")).add(Pos("pos1")).add(Pos("cmd-pos")).add(Opt("long", "l"));
 
     constexpr auto program = Program("program")
                                  .on_error(rethrow)
-                                 .add_args(Pos("pos2") * Opt("long") * Flg("flg") * Opt("longer-opt", "l") *
-                                           Pos("pos1") * Flg("glf", "g") * Flg("f") * Opt("o"))
-                                 .add_cmds(std::array{ProgramView(cmd)});
+                                 .add(Pos("pos2"))
+                                 .add(Opt("long"))
+                                 .add(Flg("flg"))
+                                 .add(Opt("longer-opt", "l"))
+                                 .add(Pos("pos1"))
+                                 .add(Flg("glf", "g"))
+                                 .add(Flg("f"))
+                                 .add(Opt("o"))
+                                 .add(cmd);
 
     WHEN("an empty argv is parsed") {
       std::array<char const *, 0> argv;

--- a/tests/opzioni.program.cpp
+++ b/tests/opzioni.program.cpp
@@ -255,7 +255,7 @@ SCENARIO("adding commands", "[Program][cmds]") {
     }
 
     WHEN("cmd is added as command of program") {
-      constexpr auto program = Program("program") + std::array{ProgramView(cmd)};
+      constexpr auto program = Program("program").add_cmds(std::array{ProgramView(cmd)});
 
       THEN("cmd should be added as only command of program") {
         REQUIRE(program.cmds.size() == 1);
@@ -284,7 +284,7 @@ SCENARIO("adding commands", "[Program][cmds]") {
     }
 
     WHEN("both cmds are added as commands of program, but cmd2 first") {
-      constexpr auto program = Program("program") + cmd2 * cmd1;
+      constexpr auto program = Program("program").add_cmds(cmd2 * cmd1);
 
       THEN("cmd1 should be added as first command of program and cmd2 as second") {
         REQUIRE(program.cmds.size() == 2);
@@ -421,10 +421,11 @@ SCENARIO("parsing", "[Program][parsing]") {
     constexpr static auto cmd =
         Program("cmd").on_error(rethrow).add_args(Flg("f") * Pos("pos1") * Pos("cmd-pos") * Opt("long", "l"));
 
-    constexpr auto program =
-        Program("program").on_error(rethrow).add_args(Pos("pos2") * Opt("long") * Flg("flg") * Opt("longer-opt", "l") *
-                                                      Pos("pos1") * Flg("glf", "g") * Flg("f") * Opt("o")) +
-        std::array{ProgramView(cmd)};
+    constexpr auto program = Program("program")
+                                 .on_error(rethrow)
+                                 .add_args(Pos("pos2") * Opt("long") * Flg("flg") * Opt("longer-opt", "l") *
+                                           Pos("pos1") * Flg("glf", "g") * Flg("f") * Opt("o"))
+                                 .add_cmds(std::array{ProgramView(cmd)});
 
     WHEN("an empty argv is parsed") {
       std::array<char const *, 0> argv;

--- a/tests/opzioni.program.cpp
+++ b/tests/opzioni.program.cpp
@@ -171,7 +171,7 @@ SCENARIO("adding arguments", "[Program][args]") {
   GIVEN("an empty Program") {
 
     WHEN("a positional is added") {
-      constexpr auto program = Program("program") + std::array{Pos("pos")};
+      constexpr auto program = Program("program").add_args(std::array{Pos("pos")});
 
       THEN("the size of args should match the number of arguments added") { REQUIRE(program.args.size() == 1); }
       THEN("cmds should not be changed") { REQUIRE(program.cmds.size() == 0); }
@@ -182,7 +182,7 @@ SCENARIO("adding arguments", "[Program][args]") {
     }
 
     WHEN("two positionals are added") {
-      constexpr auto program = Program("program") + Pos("pos1") * Pos("pos2");
+      constexpr auto program = Program("program").add_args(Pos("pos1") * Pos("pos2"));
 
       THEN("the size of args should match the number of arguments added") { REQUIRE(program.args.size() == 2); }
       THEN("cmds should not be changed") { REQUIRE(program.cmds.size() == 0); }
@@ -196,7 +196,8 @@ SCENARIO("adding arguments", "[Program][args]") {
     }
 
     WHEN("multiple positionals are added") {
-      constexpr auto program = Program("program") + Pos("pos5") * Pos("pos2") * Pos("pos4") * Pos("pos1") * Pos("pos3");
+      constexpr auto program =
+          Program("program").add_args(Pos("pos5") * Pos("pos2") * Pos("pos4") * Pos("pos1") * Pos("pos3"));
 
       THEN("the size of args should match the number of arguments added") { REQUIRE(program.args.size() == 5); }
       THEN("cmds should not be changed") { REQUIRE(program.cmds.size() == 0); }
@@ -213,8 +214,8 @@ SCENARIO("adding arguments", "[Program][args]") {
     }
 
     WHEN("other arguments are added before positionals") {
-      constexpr auto program = Program("program") + Flg("flg1") * Opt("opt2") * Pos("pos3") * Pos("pos1") *
-                                                        Pos("pos2") * Opt("opt1") * Flg("flg2");
+      constexpr auto program = Program("program").add_args(Flg("flg1") * Opt("opt2") * Pos("pos3") * Pos("pos1") *
+                                                           Pos("pos2") * Opt("opt1") * Flg("flg2"));
 
       THEN("the size of args should match the number of arguments added") { REQUIRE(program.args.size() == 7); }
       THEN("cmds should not be changed") { REQUIRE(program.cmds.size() == 0); }
@@ -418,11 +419,12 @@ SCENARIO("parsing", "[Program][parsing]") {
 
   GIVEN("a program with all kinds of arguments and a command") {
     constexpr static auto cmd =
-        Program("cmd").on_error(rethrow) + Flg("f") * Pos("pos1") * Pos("cmd-pos") * Opt("long", "l");
+        Program("cmd").on_error(rethrow).add_args(Flg("f") * Pos("pos1") * Pos("cmd-pos") * Opt("long", "l"));
 
-    constexpr auto program = Program("program").on_error(rethrow) + std::array{ProgramView(cmd)} +
-                             Pos("pos2") * Opt("long") * Flg("flg") * Opt("longer-opt", "l") * Pos("pos1") *
-                                 Flg("glf", "g") * Flg("f") * Opt("o");
+    constexpr auto program =
+        Program("program").on_error(rethrow).add_args(Pos("pos2") * Opt("long") * Flg("flg") * Opt("longer-opt", "l") *
+                                                      Pos("pos1") * Flg("glf", "g") * Flg("f") * Opt("o")) +
+        std::array{ProgramView(cmd)};
 
     WHEN("an empty argv is parsed") {
       std::array<char const *, 0> argv;


### PR DESCRIPTION
- replaced usage of `*` and `+` operators with `Program::add` member function
    - validations are now done here
    - for now, I am always arranging the correct order of arguments and commands, but that's not necessary and can eventually be optimized
    - the `operator<` for `Arg` now implements the correct logic of the order we want (positionals first, then options and flags alphabetically)
- updated tests and documentation with the new usage pattern
- little general improvements to the documentation
- added a new test to guarantee that `Arg` remains an aggregate