### PR TITLE
fix: use `action` instead of `operator[]` and remove `act` namespace

### DIFF
--- a/examples/docker.cpp
+++ b/examples/docker.cpp
@@ -25,15 +25,15 @@ int main(int argc, char const *argv[]) {
           .add(Help())
           .add(Flg("detach", "d").help("Detached mode: run command in the background"))
           .add(Opt("detach-keys").help("Override the key sequence for detaching a container"))
-          .add(Opt("env", "e").help("Set environment variables")[act::Append()])
-          .add(Opt("env-file").help("Read in a file of environment variables")[act::Append()])
+          .add(Opt("env", "e").help("Set environment variables").action(Append()))
+          .add(Opt("env-file").help("Read in a file of environment variables").action(Append()))
           .add(Flg("interactive", "i").help("Keep STDIN open even if not attached"))
           .add(Flg("privileged").help("Give extended privileges to the command"))
           .add(Flg("tty", "t").help("Allocate a pseudo-TTY"))
           .add(Opt("user", "u").help("Username or UID (format: <name|uid>[:<group|gid>])"))
           .add(Opt("workdir", "w").help("Working directory inside the container"))
           .add(Pos("container").help("Name of the target container"))
-          .add(Pos("command").help("The command to run in the container")[act::Append().gather()]);
+          .add(Pos("command").help("The command to run in the container").action(Append().gather()));
 
   constexpr static auto pull = Program("pull")
                                    .intro("Pull an image or a repository from a registry")
@@ -51,25 +51,29 @@ int main(int argc, char const *argv[]) {
           .details("Run 'docker COMMAND --help' for more information on a command.")
           .add(Help())
           .add(Version())
-          .add(Opt("config").help(
-              "Location of client config files (default {default_value})")[act::Assign().otherwise("~/.docker")])
+          .add(Opt("config")
+                   .help("Location of client config files (default {default_value})")
+                   .action(Assign().otherwise("~/.docker")))
           .add(Opt("context", "c")
                    .help(
                        "Name of the context to use to connect to the daemon (overrides DOCKER_HOST env var and default "
                        "context set with \"docker context use\")"))
           .add(Flg("debug", "D").help("Enable debug mode"))
-          .add(Opt("host", "H").help("Daemon socket(s) to connect to")[act::Append()])
+          .add(Opt("host", "H").help("Daemon socket(s) to connect to").action(Append()))
           .add(Opt("log-level", "l")
                    .help("Set the logging level (\"debug\"|\"info\"|\"warn\"|\"error\"|\"fatal\") (default "
-                         "{default_value})")[act::Assign().otherwise("info")])
+                         "{default_value})")
+                   .action(Assign().otherwise("info")))
           .add(Flg("tls").help("Use TLS; implied by --tlsverify"))
           .add(Opt("tlscacert")
-                   .help("Trust certs signed only by this CA (default {default_value})")[act::Assign().otherwise(
-                       "~/.docker/ca.pem")])
-          .add(Opt("tlscert").help(
-              "Path to TLS certificate file (default {default_value})")[act::Assign().otherwise("~/.docker/cert.pem")])
-          .add(Opt("tlskey").help(
-              "Path to TLS key file (default {default_value})")[act::Assign().otherwise("~/.docker/key.pem")])
+                   .help("Trust certs signed only by this CA (default {default_value})")
+                   .action(Assign().otherwise("~/.docker/ca.pem")))
+          .add(Opt("tlscert")
+                   .help("Path to TLS certificate file (default {default_value})")
+                   .action(Assign().otherwise("~/.docker/cert.pem")))
+          .add(Opt("tlskey")
+                   .help("Path to TLS key file (default {default_value})")
+                   .action(Assign().otherwise("~/.docker/key.pem")))
           .add(Flg("tlsverify").help("Use TLS and verify the remote"))
           .add(exec)
           .add(pull);

--- a/examples/gather.cpp
+++ b/examples/gather.cpp
@@ -14,17 +14,18 @@ int main(int argc, char const *argv[]) {
           .version("1.0")
           .add(Help())
           .add(Version())
-          .add(Pos("all").help(
-              "This is the equivalent of Python's argparse `nargs` with `+`: it requires at least one value and "
-              "consumes all of them into a vector. Note that precisely this type of argument is somewhat limiting "
-              "because, since it consumes every argument, it will not allow us to parse anything that comes after "
-              "it")[act::Append<int>().gather()])
-          .add(Opt("two").help(
-              "This is similar to the previous gather, but it limits the amount of consumed arguments to only "
-              "{gather_amount}, hence it is not so problematic. Default: {default_value}")
-                   [act::Append<int>().gather(2).otherwise(+[](ArgValue &arg) {
+          .add(Pos("all")
+                   .help("This is the equivalent of Python's argparse `nargs` with `+`: it requires at least one value "
+                         "and consumes all of them into a vector. Note that precisely this type of argument is "
+                         "somewhat limiting because, since it consumes every argument, it will not allow us to parse "
+                         "anything that comes after it")
+                   .action(Append<int>().gather()))
+          .add(Opt("two")
+                   .help("This is similar to the previous gather, but it limits the amount of consumed arguments to "
+                         "only {gather_amount}, hence it is not so problematic. Default: {default_value}")
+                   .action(Append<int>().gather(2).otherwise(+[](ArgValue &arg) {
                      arg.value = std::vector{0, 0};
-                   })]);
+                   })));
 
   auto const args = program(argc, argv);
   print("\nCommand path: {}\n", args.exec_path);

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -19,30 +19,34 @@ int main(int argc, char const *argv[]) {
           .add(Help())
           .add(Version())
           .add(Pos("name").help("Your first name"))
-          .add(Opt("double", "d").help("A double. Default: {default_value}")[act::Assign<double>().otherwise(7.11)])
+          .add(Opt("double", "d").help("A double. Default: {default_value}").action(Assign<double>().otherwise(7.11)))
           .add(Opt("last-name").help("Your last name"))
-          .add(Opt("o").help(
-              "We also support having short names only. Default: {default_value}")[act::Assign().otherwise("oh")])
+          .add(Opt("o")
+                   .help("We also support having short names only. Default: {default_value}")
+                   .action(Assign().otherwise("oh")))
           .add(Opt("num", "n")
                    .help("Creates a vector of numbers with each appearence of this argument. Default: {default_value}")
-                       [act::Append<int>()])
-          .add(Opt("csv").help("In contrast to `Append`, this will create a vector of numbers from a single "
-                               "comma-separated list of values. Default: {default_value}")[act::List<int>()])
+                   .action(Append<int>()))
+          .add(Opt("csv")
+                   .help("In contrast to `Append`, this will create a vector of numbers from a single "
+                         "comma-separated list of values. Default: {default_value}")
+                   .action(List<int>()))
           .add(Opt("verbose", "v")
                    .help("Level of verbosity. "
                          "Sets to {implicit_value} if given without a value (e.g. -{abbrev}). Default: {default_value}")
-                       [act::Assign<int>().implicitly(1).otherwise(0)])
+                   .action(Assign<int>().implicitly(1).otherwise(0)))
           .add(Flg("append", "a")
                    .help(
                        "The equivalent of Python's argparse `append_const`: will append {implicit_value} every time it "
-                       "appears in the CLI. Default: {default_value}")[act::Append<int>().implicitly(1)])
+                       "appears in the CLI. Default: {default_value}")
+                   .action(Append<int>().implicitly(1)))
           .add(Flg("flag", "f")
                    .help("The equivalent of Python's argparse `store_const`: will store \"{implicit_value}\" if it "
                          "appears in the CLI. Default: {default_value}")
-                       [act::Assign().implicitly("do something!").otherwise("nope")])
+                   .action(Assign().implicitly("do something!").otherwise("nope")))
           .add(Counter("t").help("We also support flags with only short names. This argument counts how many times it "
                                  "appears in the CLI. Default: {default_value}"))
-          .add(Opt("woo", "w").help("Woo")[act::Append<int>().gather(3)]);
+          .add(Opt("woo", "w").help("Woo").action(Append<int>().gather(3)));
 
   auto const args = program(argc, argv);
   print("\nCommand path: {}\n", args.exec_path);

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -140,9 +140,9 @@ void set_empty_vector(ArgValue &arg) noexcept {
   arg.value = std::vector<T>{};
 }
 
-// +---------+
-// | actions |
-// +---------+
+// +------------------+
+// | action functions |
+// +------------------+
 
 namespace act::fn {
 
@@ -195,7 +195,9 @@ concept Action = requires(A action) {
 
 } // namespace concepts
 
-namespace act {
+// +---------+
+// | actions |
+// +---------+
 
 template <concepts::BuiltinType Elem = std::string_view>
 class Append {
@@ -353,8 +355,6 @@ public:
   consteval DefaultValueSetter get_default_setter() const noexcept { return nullptr; }
 };
 
-} // namespace act
-
 // +-----+
 // | Arg |
 // +-----+
@@ -380,13 +380,14 @@ struct Arg {
   }
 
   template <concepts::Action Action>
-  consteval Arg operator[](Action action) const noexcept {
+  consteval Arg action(Action action) const noexcept {
     auto const &default_value = action.get_default_value();
     auto const &implicit_value = action.get_implicit_value();
-    auto arg = default_value && implicit_value ? Arg::With(*this, *default_value, *implicit_value)
-               : default_value                 ? Arg::With(*this, *default_value, std::monostate{})
-               : implicit_value                ? Arg::With(*this, std::monostate{}, *implicit_value)
-                                               : Arg::With(*this, std::monostate{}, std::monostate{});
+    auto arg = default_value && implicit_value
+                   ? Arg::With(*this, *default_value, *implicit_value)
+                   : default_value ? Arg::With(*this, *default_value, std::monostate{})
+                                   : implicit_value ? Arg::With(*this, std::monostate{}, *implicit_value)
+                                                    : Arg::With(*this, std::monostate{}, std::monostate{});
     arg.is_required = action.get_is_required();
     arg.action_fn = action.get_fn();
     arg.gather_amount = action.get_gather_amount();
@@ -527,19 +528,19 @@ consteval Arg Pos(std::string_view name) noexcept {
 // +--------------------+
 
 consteval Arg Counter(std::string_view name, std::string_view abbrev) noexcept {
-  return Flg(name, abbrev)[act::Count()];
+  return Flg(name, abbrev).action(Count());
 }
 
 consteval Arg Counter(std::string_view name) noexcept { return Counter(name, {}); }
 
 consteval Arg Help(std::string_view description) noexcept {
-  return Flg("help", "h").help(description)[act::PrintHelp()];
+  return Flg("help", "h").help(description).action(PrintHelp());
 }
 
 consteval Arg Help() noexcept { return Help("Display this information"); }
 
 consteval Arg Version(std::string_view description) noexcept {
-  return Flg("version", "V").help(description)[act::PrintVersion()];
+  return Flg("version", "V").help(description).action(PrintVersion());
 }
 
 consteval Arg Version() noexcept { return Version("Display the software version"); }
@@ -765,9 +766,9 @@ private:
   }
 };
 
-// +---------------------------+
-// | implementation of actions |
-// +---------------------------+
+// +------------------------------------+
+// | implementation of action functions |
+// +------------------------------------+
 
 namespace act::fn {
 

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -383,11 +383,10 @@ struct Arg {
   consteval Arg action(Action action) const noexcept {
     auto const &default_value = action.get_default_value();
     auto const &implicit_value = action.get_implicit_value();
-    auto arg = default_value && implicit_value
-                   ? Arg::With(*this, *default_value, *implicit_value)
-                   : default_value ? Arg::With(*this, *default_value, std::monostate{})
-                                   : implicit_value ? Arg::With(*this, std::monostate{}, *implicit_value)
-                                                    : Arg::With(*this, std::monostate{}, std::monostate{});
+    auto arg = default_value && implicit_value ? Arg::With(*this, *default_value, *implicit_value)
+               : default_value                 ? Arg::With(*this, *default_value, std::monostate{})
+               : implicit_value                ? Arg::With(*this, std::monostate{}, *implicit_value)
+                                               : Arg::With(*this, std::monostate{}, std::monostate{});
     arg.is_required = action.get_is_required();
     arg.action_fn = action.get_fn();
     arg.gather_amount = action.get_gather_amount();

--- a/src/opzioni.cpp
+++ b/src/opzioni.cpp
@@ -480,9 +480,9 @@ void HelpFormatter::print_details() const noexcept {
     out << limit_string_within(program.metadata.details, program.metadata.msg_width) << nl;
 }
 
-// +---------------------------+
-// | implementation of actions |
-// +---------------------------+
+// +------------------------------------+
+// | implementation of action functions |
+// +------------------------------------+
 
 namespace act::fn {
 


### PR DESCRIPTION
- the `act` namespace was introduced in an earlier PR, but I ended up not liking it 100% because it adds a namespace that the user has to deal with unnecessarily
- `act::fn` remains, though, since it holds stuff that is _more internal_ (but still not private)
- added a member function `Arg::action` to replace `Arg::operator[]` as the way to specify the action for the argument. This increases the consistency of the API while also making it cleaner and with a better end-result when applying clang-format