### PR TITLE
build: fix clang-format configuration

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -5,6 +5,9 @@ on: push
 jobs:
   check-formatting:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -10,6 +10,15 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v2
+
+      - name: Cache conda packages
+        uses: actions/cache@v2
+        env:
+          CACHE_VERSION: 0
+        with:
+          path: ~/conda_pkgs_dir
+          key: conda-v${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ hashFiles('environment.yml') }}
+
       - uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: opzioni

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -18,12 +18,16 @@ jobs:
 
       - name: Check examples/
         run: clang-format --dry-run --verbose -Werror examples/*.cpp
+        if: always()
 
       - name: Check include/
         run: clang-format --dry-run --verbose -Werror include/*.hpp
+        if: always()
 
       - name: Check src/
         run: clang-format --dry-run --verbose -Werror src/*.cpp
+        if: always()
 
       - name: Check tests/
         run: clang-format --dry-run --verbose -Werror tests/*.cpp
+        if: always()

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -16,8 +16,14 @@ jobs:
           auto-activate-base: false
           environment-file: environment.yml
 
-      - name: Check header files
-        run: clang-format --dry-run --verbose -Werror $(find . -path './subprojects' -prune , -name '*.hpp')
+      - name: Check examples/
+        run: clang-format --dry-run --verbose -Werror examples/*.cpp
 
-      - name: Check source files
-        run: clang-format --dry-run --verbose -Werror $(find . -path './subprojects' -prune , -name '*.cpp')
+      - name: Check include/
+        run: clang-format --dry-run --verbose -Werror include/*.hpp
+
+      - name: Check src/
+        run: clang-format --dry-run --verbose -Werror src/*.cpp
+
+      - name: Check tests/
+        run: clang-format --dry-run --verbose -Werror tests/*.cpp

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,15 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v2
+
+      - name: Cache conda packages
+        uses: actions/cache@v2
+        env:
+          CACHE_VERSION: 0
+        with:
+          path: ~/conda_pkgs_dir
+          key: conda-v${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ hashFiles('environment.yml') }}
+
       - uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: opzioni

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,10 @@ test:
 
 format:
 	clang-format --verbose -i \
-		$(shell find . -path './subprojects' -prune , -name '*.cpp') \
-		$(shell find . -path './subprojects' -prune , -name '*.hpp')
+		examples/*.cpp \
+		include/*.hpp \
+		src/*.cpp \
+		tests/*.cpp
 
 clean:
 	rm build/ -rf

--- a/include/opzioni.hpp
+++ b/include/opzioni.hpp
@@ -383,10 +383,11 @@ struct Arg {
   consteval Arg action(Action action) const noexcept {
     auto const &default_value = action.get_default_value();
     auto const &implicit_value = action.get_implicit_value();
-    auto arg = default_value && implicit_value ? Arg::With(*this, *default_value, *implicit_value)
-               : default_value                 ? Arg::With(*this, *default_value, std::monostate{})
-               : implicit_value                ? Arg::With(*this, std::monostate{}, *implicit_value)
-                                               : Arg::With(*this, std::monostate{}, std::monostate{});
+    auto arg = default_value && implicit_value
+                   ? Arg::With(*this, *default_value, *implicit_value)
+                   : default_value ? Arg::With(*this, *default_value, std::monostate{})
+                                   : implicit_value ? Arg::With(*this, std::monostate{}, *implicit_value)
+                                                    : Arg::With(*this, std::monostate{}, std::monostate{});
     arg.is_required = action.get_is_required();
     arg.action_fn = action.get_fn();
     arg.gather_amount = action.get_gather_amount();


### PR DESCRIPTION
- fixed the fact that I forgot to override the default shell in the clang-format workflow, so it was not using the one from conda
- split the clang-format checks in CI by directory
- simplified `format` rule in Makefile
- added cache for conda packages in CI